### PR TITLE
Fetch dedup metadata for existing files on recursive copy

### DIFF
--- a/python/pyxet/Cargo.lock
+++ b/python/pyxet/Cargo.lock
@@ -249,7 +249,6 @@ dependencies = [
 [[package]]
 name = "cache"
 version = "0.11.1"
-source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -274,7 +273,6 @@ dependencies = [
 [[package]]
 name = "cas_client"
 version = "0.11.1"
-source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -697,7 +695,6 @@ dependencies = [
 [[package]]
 name = "data_analysis"
 version = "0.11.1"
-source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "approx",
  "cxx",
@@ -1099,7 +1096,6 @@ dependencies = [
 [[package]]
 name = "gitxetcore"
 version = "0.11.1"
-source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1549,7 +1545,6 @@ dependencies = [
 [[package]]
 name = "libmagic"
 version = "0.11.1"
-source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "anyhow",
  "phf",
@@ -1658,7 +1653,6 @@ dependencies = [
 [[package]]
 name = "mdb_shard"
 version = "0.11.1"
-source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -1698,7 +1692,6 @@ dependencies = [
 [[package]]
 name = "merkledb"
 version = "0.11.1"
-source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -1728,7 +1721,6 @@ dependencies = [
 [[package]]
 name = "merklehash"
 version = "0.11.1"
-source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "blake3",
  "generic-array",
@@ -2172,7 +2164,6 @@ dependencies = [
 [[package]]
 name = "parutils"
 version = "0.11.1"
-source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -2340,7 +2331,6 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 [[package]]
 name = "pointer_file"
 version = "0.11.1"
-source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "toml",
  "tracing",
@@ -2424,7 +2414,6 @@ dependencies = [
 [[package]]
 name = "progress_reporting"
 version = "0.11.1"
-source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "atty",
  "crossterm",
@@ -2452,7 +2441,6 @@ dependencies = [
 [[package]]
 name = "prometheus_dict_encoder"
 version = "0.11.1"
-source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "memchr",
  "prometheus",
@@ -2832,7 +2820,6 @@ checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
 [[package]]
 name = "retry_strategy"
 version = "0.11.1"
-source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "tokio-retry",
 ]
@@ -3029,7 +3016,6 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 [[package]]
 name = "s3"
 version = "0.11.1"
-source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "chrono",
  "more-asserts 0.3.1",
@@ -3223,7 +3209,6 @@ dependencies = [
 [[package]]
 name = "shard_client"
 version = "0.11.1"
-source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4082,7 +4067,6 @@ dependencies = [
 [[package]]
 name = "utils"
 version = "0.11.1"
-source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4406,7 +4390,6 @@ dependencies = [
 [[package]]
 name = "xet_config"
 version = "0.11.1"
-source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "config",
  "dirs",
@@ -4419,7 +4402,6 @@ dependencies = [
 [[package]]
 name = "xetblob"
 version = "0.11.1"
-source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4466,43 +4448,3 @@ name = "zeroize"
 version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
-
-[[patch.unused]]
-name = "cache"
-version = "0.11.1"
-
-[[patch.unused]]
-name = "cas_client"
-version = "0.11.1"
-
-[[patch.unused]]
-name = "gitxetcore"
-version = "0.11.1"
-
-[[patch.unused]]
-name = "mdb_shard"
-version = "0.11.1"
-
-[[patch.unused]]
-name = "merkledb"
-version = "0.11.1"
-
-[[patch.unused]]
-name = "merklehash"
-version = "0.11.1"
-
-[[patch.unused]]
-name = "pointer_file"
-version = "0.11.1"
-
-[[patch.unused]]
-name = "utils"
-version = "0.11.1"
-
-[[patch.unused]]
-name = "xet_config"
-version = "0.11.1"
-
-[[patch.unused]]
-name = "xetblob"
-version = "0.11.1"

--- a/python/pyxet/Cargo.lock
+++ b/python/pyxet/Cargo.lock
@@ -249,6 +249,7 @@ dependencies = [
 [[package]]
 name = "cache"
 version = "0.11.1"
+source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -273,6 +274,7 @@ dependencies = [
 [[package]]
 name = "cas_client"
 version = "0.11.1"
+source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -695,6 +697,7 @@ dependencies = [
 [[package]]
 name = "data_analysis"
 version = "0.11.1"
+source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "approx",
  "cxx",
@@ -1096,6 +1099,7 @@ dependencies = [
 [[package]]
 name = "gitxetcore"
 version = "0.11.1"
+source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1545,6 +1549,7 @@ dependencies = [
 [[package]]
 name = "libmagic"
 version = "0.11.1"
+source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "anyhow",
  "phf",
@@ -1653,6 +1658,7 @@ dependencies = [
 [[package]]
 name = "mdb_shard"
 version = "0.11.1"
+source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -1692,6 +1698,7 @@ dependencies = [
 [[package]]
 name = "merkledb"
 version = "0.11.1"
+source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -1721,6 +1728,7 @@ dependencies = [
 [[package]]
 name = "merklehash"
 version = "0.11.1"
+source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "blake3",
  "generic-array",
@@ -2164,6 +2172,7 @@ dependencies = [
 [[package]]
 name = "parutils"
 version = "0.11.1"
+source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -2331,6 +2340,7 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 [[package]]
 name = "pointer_file"
 version = "0.11.1"
+source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "toml",
  "tracing",
@@ -2414,6 +2424,7 @@ dependencies = [
 [[package]]
 name = "progress_reporting"
 version = "0.11.1"
+source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "atty",
  "crossterm",
@@ -2441,6 +2452,7 @@ dependencies = [
 [[package]]
 name = "prometheus_dict_encoder"
 version = "0.11.1"
+source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "memchr",
  "prometheus",
@@ -2820,6 +2832,7 @@ checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
 [[package]]
 name = "retry_strategy"
 version = "0.11.1"
+source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "tokio-retry",
 ]
@@ -3016,6 +3029,7 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 [[package]]
 name = "s3"
 version = "0.11.1"
+source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "chrono",
  "more-asserts 0.3.1",
@@ -3209,6 +3223,7 @@ dependencies = [
 [[package]]
 name = "shard_client"
 version = "0.11.1"
+source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4067,6 +4082,7 @@ dependencies = [
 [[package]]
 name = "utils"
 version = "0.11.1"
+source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4390,6 +4406,7 @@ dependencies = [
 [[package]]
 name = "xet_config"
 version = "0.11.1"
+source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "config",
  "dirs",
@@ -4402,6 +4419,7 @@ dependencies = [
 [[package]]
 name = "xetblob"
 version = "0.11.1"
+source = "git+https://github.com/xetdata/xet-core#1ecd7570ea63ccbf6aba3d4876a4d822884bfbe0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4448,3 +4466,43 @@ name = "zeroize"
 version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+
+[[patch.unused]]
+name = "cache"
+version = "0.11.1"
+
+[[patch.unused]]
+name = "cas_client"
+version = "0.11.1"
+
+[[patch.unused]]
+name = "gitxetcore"
+version = "0.11.1"
+
+[[patch.unused]]
+name = "mdb_shard"
+version = "0.11.1"
+
+[[patch.unused]]
+name = "merkledb"
+version = "0.11.1"
+
+[[patch.unused]]
+name = "merklehash"
+version = "0.11.1"
+
+[[patch.unused]]
+name = "pointer_file"
+version = "0.11.1"
+
+[[patch.unused]]
+name = "utils"
+version = "0.11.1"
+
+[[patch.unused]]
+name = "xet_config"
+version = "0.11.1"
+
+[[patch.unused]]
+name = "xetblob"
+version = "0.11.1"

--- a/python/pyxet/pyxet/file_system.py
+++ b/python/pyxet/pyxet/file_system.py
@@ -578,7 +578,7 @@ class XetFS(fsspec.spec.AbstractFileSystem):
     def move(self, path1, path2, *args, **kwargs):
         return self.mv(path1, path2, *args, **kwargs)
 
-    def add_deduplication_hints(self, path_urls, min_dedup_byte_threshhold = None):
+    def add_deduplication_hints(self, path_urls):
         """
         Fetches and downloads all of the metadata needed for binary deduplication against 
         all the paths given by `paths`.  Once fetched, new data will be deduplicated against 
@@ -587,7 +587,7 @@ class XetFS(fsspec.spec.AbstractFileSystem):
         
         url_paths = [parse_url(url, self.domain, partial_remote = True) for url in path_urls]
 
-        self._add_deduplication_hints_by_url(url_paths, min_dedup_byte_threshhold)
+        self._add_deduplication_hints_by_url(url_paths)
     
 
     def _add_deduplication_hints_by_url(self, url_paths, min_dedup_byte_threshhold = None):

--- a/python/pyxet/src/lib.rs
+++ b/python/pyxet/src/lib.rs
@@ -301,6 +301,31 @@ impl PyRepo {
             ..Default::default()
         })
     }
+
+    /// Fetch shards that could be useful for dedup, according to the given endpoints.
+    ///
+    /// Endpoints are given as a list of (branch, path) tuples.  Shard hint fetches may be
+    /// across branches.
+    ///
+    /// If min_num_bytes_in_dedup is specified, then only shards that collectively define
+    /// that many bytes are actually downloaded; any hinted shards that don't specify at least
+    /// the minimum number of bytes in chunks are ignored.
+    ///
+    pub fn fetch_hinted_shards_for_dedup(
+        &self,
+        file_paths: Vec<(&str, &str)>,
+        min_dedup_bytes_for_shard_downloading: Option<usize>,
+    ) -> PyResult<()> {
+        let res = exec_async_anyhow!(
+            self.repo
+                .fetch_hinted_shards_for_dedup(
+                    &file_paths,
+                    min_dedup_bytes_for_shard_downloading.unwrap_or(0)
+                )
+                .await
+        );
+        Ok(res)
+    }
 }
 
 #[pyclass(subclass)]


### PR DESCRIPTION
This PR adds in a step on a recursive download to fetch the shard hints associated with the destination files.  
It also adds an API for the use to manually specify possible files to dedup against. 
