### PR TITLE
Allow printing to file

### DIFF
--- a/python/pyxet/pyxet/file_interface.py
+++ b/python/pyxet/pyxet/file_interface.py
@@ -106,6 +106,8 @@ class XetFile:
             raise ValueError("I/O operation on closed file.")
         if self._do_not_write:
             return
+        if isinstance(data, str):
+            data = data.encode('utf-8')
         self.handle.write(data)
 
     def __del__(self):


### PR DESCRIPTION
Currently many ways to print /write to a pyxet file result in the error "string argument without an encoding"
This allows write() to take a str, in which case it will default convert to utf-8