### PR TITLE
[chore] - Refactor functionalities to a pyxet.core.py 

### DIFF
--- a/python/pyxet/pyxet/__init__.py
+++ b/python/pyxet/pyxet/__init__.py
@@ -1,6 +1,7 @@
 from .file_system import open, login, XetFS
 from .version import __version__
 from .cli import PyxetCLI, BranchCLI, RepoCLI
+from .core import _copy as copy, _mv as move, _rm as remove, _info as info, _duplicate as duplicate
 
 """
 PyXet

--- a/python/pyxet/pyxet/__init__.py
+++ b/python/pyxet/pyxet/__init__.py
@@ -1,7 +1,9 @@
 from .file_system import open, login, XetFS
 from .version import __version__
 from .cli import PyxetCLI, BranchCLI, RepoCLI
-from .core import _copy as copy, _mv as move, _rm as remove, _info as info, _duplicate as duplicate, _mount as mount
+from .core import _copy as copy, _mv as move, _rm as remove, _info as info, _duplicate as duplicate, _mount as mount, \
+    clone, fork_repo, make_repo, list_repos, list_branches, rename_repo, delete_branch, get_branch_info, \
+    make_branch
 
 """
 PyXet

--- a/python/pyxet/pyxet/__init__.py
+++ b/python/pyxet/pyxet/__init__.py
@@ -1,7 +1,7 @@
 from .file_system import open, login, XetFS
 from .version import __version__
 from .cli import PyxetCLI, BranchCLI, RepoCLI
-from .core import _copy as copy, _mv as move, _rm as remove, _info as info, _duplicate as duplicate
+from .core import _copy as copy, _mv as move, _rm as remove, _info as info, _duplicate as duplicate, _mount as mount
 
 """
 PyXet

--- a/python/pyxet/pyxet/cli.py
+++ b/python/pyxet/pyxet/cli.py
@@ -1,20 +1,18 @@
 import typer
 from typing_extensions import Annotated
 import pyxet
-import argparse
-import fsspec
+
 import sys
-from concurrent.futures import ThreadPoolExecutor
 import threading
 import os
 import typing
 from tabulate import tabulate
 from .file_system import XetFS
 from .url_parsing import parse_url
-from .rpyxet import rpyxet
 from .version import __version__
 import subprocess
-
+from pyxet.config import CHUNK_SIZE
+import pyxet.core
 
 cli = typer.Typer(add_completion=True, short_help="a pyxet command line interface", no_args_is_help=True)
 repo = typer.Typer(add_completion=False, short_help="sub-commands to manage repositories")
@@ -22,247 +20,6 @@ branch = typer.Typer(add_completion=False, short_help="sub-commands to manage br
 
 cli.add_typer(repo, name="repo")
 cli.add_typer(branch, name="branch")
-
-MAX_CONCURRENT_COPIES = threading.Semaphore(32)
-CHUNK_SIZE = 16*1024*1024
-
-
-def _ltrim_match(s, match):
-    """
-    Trims the string 'match' from the left of the string 's'
-    raising an error if the match does not exist.
-    Ex:
-    ```
-       ltrim_match("a/b/c.txt", "a/b") => "/c.txt"
-    ```
-    Used to compute relative paths.
-    """
-    if len(s) < len(match):
-        raise(ValueError(f"Path {s} not in directory {match}"))
-    if s[:len(match)] != match:
-        raise(ValueError(f"Path {s} not in directory {match}"))
-    return s[len(match):]
-
-
-def _get_fs_and_path(uri):
-    if uri.find('://') == -1:
-        fs = fsspec.filesystem("file")
-        uri = os.path.abspath(uri)
-        return fs, uri
-    else:
-        split = uri.split("://")
-        if len(split) != 2:
-            print(f"Invalid URL: {uri}", file=sys.stderr)
-        if split[0] == 'xet':
-            fs = pyxet.XetFS()
-        else:
-            fs = fsspec.filesystem(split[0])
-            # this is *really* annoying But the s3fs protocol has 
-            # protocol as a list ['s3','s3a']
-            if isinstance(fs.protocol, list):
-                fs.protocol = split[0]
-        return fs, split[1]
-
-
-def _single_file_copy(src_fs, src_path, dest_fs, dest_path,
-                     buffer_size=CHUNK_SIZE, size_hint = None):
-    if dest_path.split('/')[-1] == '.gitattributes':
-        print("Skipping .gitattributes as that is required for Xet Magic")
-        return
-    print(f"Copying {src_path} to {dest_path}...")
-
-    if src_fs.protocol == 'xet' and dest_fs.protocol == 'xet':
-        dest_fs.cp_file(src_path, dest_path)
-        return
-    with MAX_CONCURRENT_COPIES:
-        try:
-            if dest_fs.protocol == "xet":
-                if size_hint is None:
-                    size_hint = src_fs.info(src_path).get('size', None)
-       
-                # Heuristic for now -- if the size of the source is larger than 50MB,
-                # then make sure we have any shards for the destination that work.
-                if size_hint is not None and size_hint >= 50000000:
-                    dest_fs.add_deduplication_hints(dest_path)
-
-            with src_fs.open(src_path, "rb") as source_file:
-                with dest_fs.open(dest_path, "wb", auto_mkdir=True) as dest_file:
-                    # Buffered copy in chunks
-                    while True:
-                        chunk = source_file.read(buffer_size)
-                        if not chunk:
-                            break
-                        dest_file.write(chunk)
-        except Exception as e:
-            proto = src_fs.protocol
-            print(f"Failed to copy {proto}://{src_path}: {e}")
-
-def _validate_xet_copy(src_fs, src_path, dest_fs, dest_path):
-    """
-    Performs some basic early validation of a xet to avoid issues later.
-    Does not catch all failure conditions, but catches some early enough to
-    avoid doing a lot of unnecessary work, then fail.
-
-    Raises an exception on failure, returns True on success
-    """
-    srcproto = src_fs.protocol
-    destproto = dest_fs.protocol
-    # if src is a xet, there must be a branch to copy from
-    if srcproto == 'xet':
-        src_fs.branch_info(src_path)
-
-    if destproto == 'xet':
-        # check dest branch exists 
-        # exists before we try to do any copying
-        # An exception is that if this operation would create a branch
-        if srcproto == 'xet':
-            src_parse = parse_url(src_path, src_fs.domain)
-            dest_parse = parse_url(dest_path, dest_fs.domain)
-            if src_parse.path == '' and dest_parse.path == '':
-                # this is a branch to branch copy
-                return True
-
-        dest_fs.branch_info(dest_path)
-
-def _isdir(fs, path):
-    if fs.protocol == 'xet':
-        return fs.isdir_or_branch(path)
-    else:
-        return fs.isdir(path)
-
-def _copy(source, destination, recursive = True, _src_fs=None, _dest_fs=None):
-    src_fs, src_path = _get_fs_and_path(source)
-    dest_fs, dest_path = _get_fs_and_path(destination)
-    if _src_fs is not None:
-        src_fs = _src_fs
-    if _dest_fs is not None:
-        dest_fs = _dest_fs
-    srcproto = src_fs.protocol
-    destproto = dest_fs.protocol
-
-    _validate_xet_copy(src_fs, src_path, dest_fs, dest_path)
-
-    # normalize trailing '/' by just removing them unless the path
-    # is exactly just '/'
-    if src_path != '/':
-        src_path = src_path.rstrip('/')
-    if dest_path != '/':
-        dest_path = dest_path.rstrip('/')
-    src_isdir = _isdir(src_fs, src_path)
-    
-    # Handling wildcard cases
-    if '*' in src_path:
-        # validate
-        # we only accept globs of the for blah/blah/blah/[glob]
-        # i.e. the glob is only in the last component
-        # src_root_dir should be blah/blah/blah here
-        src_root_dir = '/'.join(src_path.split('/')[:-1])
-        if '*' in src_root_dir:
-            raise ValueError(f"Invalid glob {source}. Wildcards can only appear in the last position")
-        # The source path contains a wildcard
-        with ThreadPoolExecutor() as executor:
-            futures = []
-            for path, info in src_fs.glob(src_path, detail=True).items():
-                # Copy each matching file
-                if info['type'] == 'directory' and not recursive:
-                    continue
-                relpath = _ltrim_match(path, src_root_dir).lstrip('/')
-                if dest_path == '/':
-                    dest_for_this_path = f"/{relpath}"
-                else:
-                    dest_for_this_path = f"{dest_path}/{relpath}"
-                dest_dir = '/'.join(dest_for_this_path.split('/')[:-1])
-                dest_fs.makedirs(dest_dir, exist_ok=True)
-
-                if info['type'] == 'directory':
-                    futures.append(
-                        executor.submit(
-                            _copy,
-                            f"{src_fs.protocol}://{path}",
-                            f"{dest_fs.protocol}://{dest_for_this_path}",
-                            recursive=True,
-                            _src_fs=src_fs,
-                            _dest_fs=dest_fs,
-                        )
-                    )
-                else:
-                    futures.append(
-                        executor.submit(
-                            _single_file_copy,
-                            src_fs,
-                            f"{path}",
-                            dest_fs,
-                            dest_for_this_path,
-                            size_hint = info.get('size', None)
-                        ))
-
-
-            for future in futures:
-                future.result()
-        return
-
-    # Handling directories
-    if src_isdir:
-        # Recursively copy
-        # xet cp_file can cp directories
-        if srcproto == 'xet' and destproto == 'xet':
-            print(f"Copying {src_path} to {dest_path}...")
-            dest_fs.cp_file(src_path, dest_path)
-            return
-        with ThreadPoolExecutor() as executor:
-            futures = []
-            for path,info in src_fs.find(src_path, detail=True).items():
-                if info['type'] == 'directory' and not recursive:
-                    continue
-                # Note that path is a full path
-                # we need to relativize to make the destination path
-                relpath = _ltrim_match(path, src_path).lstrip('/')
-                if dest_path == '/':
-                    dest_for_this_path = f"/{relpath}"
-                else:
-                    dest_for_this_path = f"{dest_path}/{relpath}"
-                dest_dir = '/'.join(dest_for_this_path.split('/')[:-1])
-                dest_fs.makedirs(dest_dir, exist_ok=True)
-                # Submitting copy jobs to thread pool
-                futures.append(
-                        executor.submit(
-                            _single_file_copy,
-                            src_fs,
-                            f"{path}",
-                            dest_fs,
-                            dest_for_this_path,
-                            size_hint = info.get('size', None)
-                            ))
-            # Waiting for all copy jobs to complete
-            for future in futures:
-                future.result()
-        return
-
-    _single_file_copy(src_fs, src_path, dest_fs, dest_path)
-
-
-def _root_copy(source, destination, message, recursive=False):
-    dest_fs, dest_path = _get_fs_and_path(destination)
-    destproto_is_xet = dest_fs.protocol == 'xet'
-    dest_isdir = _isdir(dest_fs, dest_path)
-
-    # Our target is an existing directory and src is not a wildcard copy
-    # i.e. we are getting cp src/some/path to dest/some/where
-    # but dest/some/where exists as a directory
-    # So we will need to make the dest dest/some/where/path
-    if dest_isdir and '*' not in source:
-        # split up the final component from source path and add it
-        # to the destination
-        final_source_component = source.split('/')[-1]
-        if not destination.endswith('/'):
-            destination += '/'
-        destination += final_source_component
-
-    if destproto_is_xet:
-        dest_fs.start_transaction(message)
-    _copy(source, destination, recursive)
-    if destproto_is_xet:
-        dest_fs.end_transaction()
 
 
 class PyxetCLI:
@@ -272,12 +29,14 @@ class PyxetCLI:
               user: Annotated[str, typer.Option("--user", "-u", help="user name")],
               password: Annotated[str, typer.Option("--password", "-p", help="password")],
               host: Annotated[str, typer.Option("--host", "-h", help="host to authenticate against")] = "xethub.com",
-              force: Annotated[bool, typer.Option("--force", "-f", help="do not perform authentication check and force write to config")] = False,
-              no_overwrite: Annotated[bool, typer.Option("--no_overwrite", help="Do not overwrite if existing auth information is found")] = False):
+              force: Annotated[bool, typer.Option("--force", "-f",
+                                                  help="do not perform authentication check and force write to config")] = False,
+              no_overwrite: Annotated[bool, typer.Option("--no_overwrite",
+                                                         help="Do not overwrite if existing auth information is found")] = False):
         """
         Configures the login information. Stores the config in ~/.xetconfig
         """
-        rpyxet.configure_login(host,user,email,password,force,no_overwrite)
+        pyxet.core.configure_login(email, user, password,host, force, no_overwrite)
 
     @staticmethod
     @cli.command()
@@ -299,27 +58,29 @@ class PyxetCLI:
             if path != letter and path != letter + ':' and path != letter + ':\\':
                 raise ValueError("Path must be a drive letter of the form X:")
             path = letter
-        rpyxet.perform_mount(sys.executable, source.remote, path, source.branch, prefetch)
+        pyxet.core.perform_mount(source.remote, path, source.branch, prefetch)
 
     @staticmethod
     @cli.command(name="mount-curdir", hidden=True)
     def mount_curdir(path: Annotated[str, typer.Argument(help="path to mount to")],
-                     autostop: Annotated[bool, typer.Option('--autostop',help="Automatically terminates on unmount")] = False,
-                     reference: Annotated[str, typer.Option('--reference', '-r', help="branch or revision to mount")] = 'HEAD',
+                     autostop: Annotated[
+                         bool, typer.Option('--autostop', help="Automatically terminates on unmount")] = False,
+                     reference: Annotated[
+                         str, typer.Option('--reference', '-r', help="branch or revision to mount")] = 'HEAD',
                      prefetch: Annotated[int, typer.Option('--prefetch', '-p', help="prefetch aggressiveness")] = 16,
-                     ip: Annotated[str, typer.Option('--ip',help="IP used to host the NFS server")] = "127.0.0.1",
-                     writable: Annotated[bool, typer.Option('--writable',help="Experimental. Do not use")] = False,
-                     signal: Annotated[int, typer.Option('--signal',help="Internal:Sends SIGUSR1 to this pid")] = -1):
+                     ip: Annotated[str, typer.Option('--ip', help="IP used to host the NFS server")] = "127.0.0.1",
+                     writable: Annotated[bool, typer.Option('--writable', help="Experimental. Do not use")] = False,
+                     signal: Annotated[int, typer.Option('--signal', help="Internal:Sends SIGUSR1 to this pid")] = -1):
         """
         Internal Do not use
         """
-        rpyxet.perform_mount_curdir(path=path, 
-                                    reference=reference,
-                                    signal=signal,
-                                    autostop=autostop,
-                                    prefetch=prefetch,
-                                    ip=ip,
-                                    writable=writable)
+        pyxet.core.perform_mount_curdir(path=path,
+                                        reference=reference,
+                                        signal=signal,
+                                        autostop=autostop,
+                                        prefetch=prefetch,
+                                        ip=ip,
+                                        writable=writable)
 
     @staticmethod
     @cli.command()
@@ -339,7 +100,6 @@ class PyxetCLI:
         print(f"Running '{strcommand}'")
         subprocess.run(["git-xet", "clone"] + [source.remote] + args)
 
-
     @staticmethod
     @cli.command()
     def version():
@@ -348,6 +108,7 @@ class PyxetCLI:
         """
         print(__version__)
 
+    @staticmethod
     @cli.command()
     def cp(source: Annotated[str, typer.Argument(help="Source file or folder which will be copied")],
            target: Annotated[str, typer.Argument(help="Target location of the file or folder")],
@@ -360,15 +121,15 @@ class PyxetCLI:
         """copy files and folders"""
         if not message:
             message = f"copy {source} to {target}" if not recursive else f"copy {source} to {target} recursively"
-        MAX_CONCURRENT_COPIES = threading.Semaphore(parallel)
-        _root_copy(source, target, message, recursive=recursive)
+        max_concurrent_copies = threading.Semaphore(parallel)
+        pyxet.core._root_copy(source, target, message, recursive=recursive, max_concurrent_copies=max_concurrent_copies)
 
     @staticmethod
     @cli.command()
     def ls(path: Annotated[str, typer.Argument(help="Source file or folder which will be copied")] = "xet://",
            raw: Annotated[bool, typer.Option(help="If True, will print the raw JSON output")] = False):
         """list files and folders"""
-        fs, path = _get_fs_and_path(path)
+        fs, path = pyxet.core._get_fs_and_path(path)
         try:
             listing = fs.ls(path, detail=True)
             if raw:
@@ -383,9 +144,9 @@ class PyxetCLI:
     @staticmethod
     @cli.command()
     def cat(path: Annotated[str, typer.Argument(help="Source file or folder which will be printed")],
-           limit: Annotated[int, typer.Option(help="Maximum number of bytes to print")] = 0):
+            limit: Annotated[int, typer.Option(help="Maximum number of bytes to print")] = 0):
         """Prints a file to stdout"""
-        fs, path = _get_fs_and_path(path)
+        fs, path = pyxet.core._get_fs_and_path(path)
         try:
             file = fs.open(path, 'rb')
             if limit == 0:
@@ -407,25 +168,7 @@ class PyxetCLI:
            message: Annotated[
                str, typer.Option("--message", "-m", help="A commit message")] = ""):
         """delete files and folders"""
-        if not message:
-            message = f"delete {paths}"
-        fs, _ = _get_fs_and_path(paths[0])
-        try:
-            destproto_is_xet = fs.protocol == 'xet'
-            if destproto_is_xet:
-                for path in paths:
-                    parsed_path = parse_url(path, fs.domain)
-                    if len(parsed_path.path) == 0 and len(parsed_path.branch) > 0:
-                        print("Cannot delete branches with 'rm' as this is a non-reversible operation and history will not be preserved. Use 'xet branch del'", file=sys.stderr)
-                        return
-                fs.start_transaction(message)
-            for path in paths:
-                fs.rm(path)
-            if destproto_is_xet:
-                fs.end_transaction()
-        except Exception as e:
-            print(f"{e}")
-            return
+        pyxet.core._rm(paths, message=message)
 
     @staticmethod
     @cli.command()
@@ -436,31 +179,15 @@ class PyxetCLI:
            message: Annotated[
                str, typer.Option("--message", "-m", help="A commit message")] = ""):
         """move files and folders"""
-        if not message:
-            message = f"move {source} to {target}" if not recursive else f"move {source} to {target} recursively"
-        src_fs, src_path = _get_fs_and_path(source)
-        dest_fs, dest_path = _get_fs_and_path(target)
-        if src_fs.protocol != dest_fs.protocol:
-            print("Unable to move between different protocols {src_fs.protocol}, {dest_fs.protocol}\nYou may want to copy instead", file=sys.stderr)
-        destproto_is_xet = dest_fs.protocol == 'xet'
-        try:
-            if destproto_is_xet:
-                dest_fs.start_transaction(message)
-            dest_fs.mv(src_path, dest_path)
-            if destproto_is_xet:
-                dest_fs.end_transaction()
-        except Exception as e:
-            print(f"{e}")
-            return
+        pyxet.core._mv(source, target, recursive=recursive, message=message)
 
     @staticmethod
     @cli.command()
     def info(uri: Annotated[str, typer.Argument(help="a uri of the structure <user>/<project>/<branch>")],
              raw: Annotated[bool, typer.Option(help="If True, will print the raw JSON output")] = False):
         """Provide information about a project branch"""
-        fs, path = _get_fs_and_path(uri)
         try:
-            info = fs.info(path)
+            info = pyxet.core._info(uri)
             if raw:
                 print(info)
             else:
@@ -476,36 +203,14 @@ class PyxetCLI:
                   dest: Annotated[str, typer.Argument(help="new repository name")] = None,
                   private: Annotated[bool, typer.Option('--private', help="make repository private")] = False,
                   public: Annotated[bool, typer.Option('--public', help="make repository public")] = False,
-             ):
+                  ):
         """
         Duplicates (via a detached fork) a copy of a repository from xet://[user]/[repo] to your own account.
         Defaults to original repository private/public settings. Use --private or --public to adjust the repository permissions. 
         If dest is not provided, xet://[yourusername]/[repo] is used.
         Use `xet fork` if you want a regular fork.
         """
-
-        fs = XetFS()
-        if dest is None:
-            repo_name = source.rstrip('/').split('/')[-1]
-            dest = "xet://" + fs.get_username() + "/" + repo_name
-            print(f"Duplicating to {dest}")
-        else:
-            repo_name = source.rstrip('/').split('/')[-1]
-        fs.duplicate_repo(source, dest)
-        try:
-            if private:
-                print(f"Duplicate Success. Changing permissions...")
-                fs.set_repo_attr(dest, "private", True)
-                print(f"Repo permissions set successfully")
-            if public:
-                print(f"Duplicate Success. Changing permissions...")
-                fs.set_repo_attr(dest, "public", False)
-                print(f"Repo permissions set successfully")
-        except Exception as e:
-            username = fs.get_username()
-            print(f"An error has occurred setting repository permissions: {e}")
-            print("Permission changes may not have been made. Please change it manually at:")
-            print(f"  {fs.domain}/{username}/{repo_name}/settings")
+        pyxet.core._duplicate(source, dest, private, public, verbose=True)
 
 
 class BranchCLI:
@@ -522,20 +227,20 @@ class BranchCLI:
 
             xet branch make xet://user/repo main new_branch
         """
-        fs, remote = _get_fs_and_path(repo)
-        assert(fs.protocol == 'xet')
-        assert('/' not in dest_branch)
+        fs, remote = pyxet.core._get_fs_and_path(repo)
+        assert (fs.protocol == 'xet')
+        assert ('/' not in dest_branch)
         fs.make_branch(remote, src_branch, dest_branch)
 
     @staticmethod
     @branch.command()
     def ls(repo: Annotated[str, typer.Argument(help="a repository name <user>/<project>")],
-             raw: Annotated[bool, typer.Option(help="If True, will print the raw JSON output")] = False):
+           raw: Annotated[bool, typer.Option(help="If True, will print the raw JSON output")] = False):
         """
         list branches of a project.
         """
-        fs, path = _get_fs_and_path(repo)
-        assert(fs.protocol == 'xet')
+        fs, path = pyxet.core_get_fs_and_path(repo)
+        assert (fs.protocol == 'xet')
         try:
             listing = fs.list_branches(repo, raw)
             if raw:
@@ -563,12 +268,11 @@ class BranchCLI:
         print("", file=sys.stderr)
         if yes:
             print("--yes is set. Issuing deletion", file=sys.stderr)
-            fs, path = _get_fs_and_path(repo)
-            assert(fs.protocol == 'xet')
+            fs, path = pyxet.core_get_fs_and_path(repo)
+            assert (fs.protocol == 'xet')
             return fs.delete_branch(repo, branch)
         else:
             print("Add --yes to delete", file=sys.stderr)
-
 
     @staticmethod
     @branch.command()
@@ -577,8 +281,8 @@ class BranchCLI:
         """
         Prints information about a branch
         """
-        fs, path = _get_fs_and_path(repo)
-        assert(fs.protocol == 'xet')
+        fs, path = pyxet.core_get_fs_and_path(repo)
+        assert (fs.protocol == 'xet')
         ret = fs.find_ref(repo, branch)
         print(ret)
         return ret
@@ -605,7 +309,6 @@ class RepoCLI:
             print("Repo permissions set successfully")
         print(ret)
 
-
     @staticmethod
     @repo.command()
     def fork(source: Annotated[str, typer.Argument(help="origin repo to fork from")],
@@ -625,7 +328,6 @@ class RepoCLI:
             print(f"Forking to {dest}")
         fs.fork_repo(source, dest)
 
-
     @staticmethod
     @repo.command()
     def ls(raw: Annotated[bool, typer.Option(help="If True, will print the raw JSON output")] = False):
@@ -639,7 +341,7 @@ class RepoCLI:
                 print(repos)
             else:
                 print(tabulate(repos, headers="keys"))
-            return ls
+            return
         except Exception as e:
             print(f"{e}")
             return

--- a/python/pyxet/pyxet/cli.py
+++ b/python/pyxet/pyxet/cli.py
@@ -4,13 +4,10 @@ import pyxet
 
 import sys
 import threading
-import os
 import typing
 from tabulate import tabulate
 from .file_system import XetFS
-from .url_parsing import parse_url
 from .version import __version__
-import subprocess
 from pyxet.config import CHUNK_SIZE
 import pyxet.core
 

--- a/python/pyxet/pyxet/cli.py
+++ b/python/pyxet/pyxet/cli.py
@@ -77,16 +77,10 @@ class PyxetCLI:
         """
         Clones a repository on a local path
         """
-        res = subprocess.run(["git-xet", "-V"], capture_output=True)
-        if res.returncode != 0:
+        if pyxet.core._validate_git_xet() is False:
             print("git-xet not found. Please install git-xet from https://xethub.com/explore/install")
             return
-        fs = XetFS()
-        source = parse_url(source, fs.domain)
-        commands = ["git-xet", "clone"] + [source.remote] + args
-        strcommand = ' '.join(commands)
-        print(f"Running '{strcommand}'")
-        subprocess.run(["git-xet", "clone"] + [source.remote] + args)
+        pyxet.core._clone(source, args)
 
     @staticmethod
     @cli.command()
@@ -310,9 +304,8 @@ class RepoCLI:
         """
         list repositories of a user.
         """
-        fs = XetFS()
         try:
-            repos = fs.list_repos(raw)
+            repos = pyxet.core._list_repos(raw)
             if raw:
                 print(repos)
             else:
@@ -329,8 +322,7 @@ class RepoCLI:
         """
         Forks a new repository from an existing repository.
         """
-        fs = XetFS()
-        fs.rename_repo(source, dest)
+        pyxet._rename_repo(source, dest)
 
     @staticmethod
     @repo.command()

--- a/python/pyxet/pyxet/cli.py
+++ b/python/pyxet/pyxet/cli.py
@@ -46,19 +46,7 @@ class PyxetCLI:
         """
         Mounts a repository on a local path
         """
-        fs = XetFS()
-        source = parse_url(source, fs.domain)
-        if source.path != '':
-            raise ValueError("Cannot have a path when mounting. Expecting only xet://user/repo/branch")
-        if source.branch == '':
-            raise ValueError("Branch or revision must be specified")
-        if os.name == 'nt':
-            # path must be a drive letter (X, or X: or X:\\)
-            letter = path[0]
-            if path != letter and path != letter + ':' and path != letter + ':\\':
-                raise ValueError("Path must be a drive letter of the form X:")
-            path = letter
-        pyxet.core.perform_mount(source.remote, path, source.branch, prefetch)
+        pyxet.core._mount(source, path, prefetch)
 
     @staticmethod
     @cli.command(name="mount-curdir", hidden=True)
@@ -74,13 +62,13 @@ class PyxetCLI:
         """
         Internal Do not use
         """
-        pyxet.core.perform_mount_curdir(path=path,
-                                        reference=reference,
-                                        signal=signal,
-                                        autostop=autostop,
-                                        prefetch=prefetch,
-                                        ip=ip,
-                                        writable=writable)
+        pyxet.core._perform_mount_curdir(path=path,
+                                         reference=reference,
+                                         signal=signal,
+                                         autostop=autostop,
+                                         prefetch=prefetch,
+                                         ip=ip,
+                                         writable=writable)
 
     @staticmethod
     @cli.command()

--- a/python/pyxet/pyxet/cli.py
+++ b/python/pyxet/pyxet/cli.py
@@ -36,7 +36,7 @@ class PyxetCLI:
         """
         Configures the login information. Stores the config in ~/.xetconfig
         """
-        pyxet.core.configure_login(email, user, password,host, force, no_overwrite)
+        pyxet.core.configure_login(email, user, password, host, force, no_overwrite)
 
     @staticmethod
     @cli.command()
@@ -107,8 +107,6 @@ class PyxetCLI:
            parallel: Annotated[
                int, typer.Option("--parallel", "-p", help="Maximum amount of parallelism")] = 32):
         """copy files and folders"""
-        if not message:
-            message = f"copy {source} to {target}" if not recursive else f"copy {source} to {target} recursively"
         max_concurrent_copies = threading.Semaphore(parallel)
         pyxet.core._root_copy(source, target, message, recursive=recursive, max_concurrent_copies=max_concurrent_copies)
 
@@ -117,9 +115,8 @@ class PyxetCLI:
     def ls(path: Annotated[str, typer.Argument(help="Source file or folder which will be copied")] = "xet://",
            raw: Annotated[bool, typer.Option(help="If True, will print the raw JSON output")] = False):
         """list files and folders"""
-        fs, path = pyxet.core._get_fs_and_path(path)
         try:
-            listing = fs.ls(path, detail=True)
+            listing = pyxet.core._list(path, detail=True)
             if raw:
                 print(listing)
             else:
@@ -215,10 +212,7 @@ class BranchCLI:
 
             xet branch make xet://user/repo main new_branch
         """
-        fs, remote = pyxet.core._get_fs_and_path(repo)
-        assert (fs.protocol == 'xet')
-        assert ('/' not in dest_branch)
-        fs.make_branch(remote, src_branch, dest_branch)
+        pyxet.core._make_branch(repo, src_branch, dest_branch)
 
     @staticmethod
     @branch.command()
@@ -227,10 +221,8 @@ class BranchCLI:
         """
         list branches of a project.
         """
-        fs, path = pyxet.core_get_fs_and_path(repo)
-        assert (fs.protocol == 'xet')
         try:
-            listing = fs.list_branches(repo, raw)
+            listing = pyxet.core._list_branches(repo, raw)
             if raw:
                 print(listing)
             else:
@@ -256,9 +248,7 @@ class BranchCLI:
         print("", file=sys.stderr)
         if yes:
             print("--yes is set. Issuing deletion", file=sys.stderr)
-            fs, path = pyxet.core_get_fs_and_path(repo)
-            assert (fs.protocol == 'xet')
-            return fs.delete_branch(repo, branch)
+            return pyxet.core._delete_branch(repo, branch)
         else:
             print("Add --yes to delete", file=sys.stderr)
 
@@ -269,9 +259,7 @@ class BranchCLI:
         """
         Prints information about a branch
         """
-        fs, path = pyxet.core_get_fs_and_path(repo)
-        assert (fs.protocol == 'xet')
-        ret = fs.find_ref(repo, branch)
+        ret = pyxet.core._info_branch(repo, branch)
         print(ret)
         return ret
 

--- a/python/pyxet/pyxet/cli.py
+++ b/python/pyxet/pyxet/cli.py
@@ -80,7 +80,7 @@ class PyxetCLI:
         if pyxet.core._validate_git_xet() is False:
             print("git-xet not found. Please install git-xet from https://xethub.com/explore/install")
             return
-        pyxet.core._clone(source, args)
+        pyxet.core._clone(source, *args)
 
     @staticmethod
     @cli.command()

--- a/python/pyxet/pyxet/cli.py
+++ b/python/pyxet/pyxet/cli.py
@@ -206,7 +206,7 @@ class BranchCLI:
 
             xet branch make xet://user/repo main new_branch
         """
-        pyxet.core._make_branch(repo, src_branch, dest_branch)
+        pyxet.core.make_branch(repo, src_branch, dest_branch)
 
     @staticmethod
     @branch.command()
@@ -216,7 +216,7 @@ class BranchCLI:
         list branches of a project.
         """
         try:
-            listing = pyxet.core._list_branches(repo, raw)
+            listing = pyxet.core.list_branches(repo, raw)
             if raw:
                 print(listing)
             else:
@@ -242,7 +242,7 @@ class BranchCLI:
         print("", file=sys.stderr)
         if yes:
             print("--yes is set. Issuing deletion", file=sys.stderr)
-            return pyxet.core._delete_branch(repo, branch)
+            return pyxet.core.delete_branch(repo, branch)
         else:
             print("Add --yes to delete", file=sys.stderr)
 
@@ -253,7 +253,7 @@ class BranchCLI:
         """
         Prints information about a branch
         """
-        ret = pyxet.core._info_branch(repo, branch)
+        ret = pyxet.core.get_branch_info(repo, branch)
         print(ret)
         return ret
 
@@ -305,7 +305,7 @@ class RepoCLI:
         list repositories of a user.
         """
         try:
-            repos = pyxet.core._list_repos(raw)
+            repos = pyxet.core.list_repos(raw)
             if raw:
                 print(repos)
             else:

--- a/python/pyxet/pyxet/config.py
+++ b/python/pyxet/pyxet/config.py
@@ -1,0 +1,4 @@
+import threading
+
+MAX_CONCURRENT_COPIES = threading.Semaphore(32)
+CHUNK_SIZE = 16*1024*1024

--- a/python/pyxet/pyxet/core.py
+++ b/python/pyxet/pyxet/core.py
@@ -1,0 +1,377 @@
+import threading
+import typing
+
+import pyxet
+import fsspec
+import sys
+from concurrent.futures import ThreadPoolExecutor
+import os
+
+from .config import CHUNK_SIZE, MAX_CONCURRENT_COPIES
+from .url_parsing import parse_url
+from .rpyxet import rpyxet
+from .file_system import XetFS
+
+
+def _ltrim_match(s, match):
+    """
+    Trims the string 'match' from the left of the string 's'
+    raising an error if the match does not exist.
+    Ex:
+    ```
+       ltrim_match("a/b/c.txt", "a/b") => "/c.txt"
+    ```
+    Used to compute relative paths.
+    """
+    if len(s) < len(match):
+        raise (ValueError(f"Path {s} not in directory {match}"))
+    if s[:len(match)] != match:
+        raise (ValueError(f"Path {s} not in directory {match}"))
+    return s[len(match):]
+
+
+def _get_fs_and_path(uri):
+    if uri.find('://') == -1:
+        fs = fsspec.filesystem("file")
+        uri = os.path.abspath(uri)
+        return fs, uri
+    else:
+        split = uri.split("://")
+        if len(split) != 2:
+            print(f"Invalid URL: {uri}", file=sys.stderr)
+        if split[0] == 'xet':
+            fs = pyxet.XetFS()
+        else:
+            fs = fsspec.filesystem(split[0])
+            # this is *really* annoying But the s3fs protocol has
+            # protocol as a list ['s3','s3a']
+            if isinstance(fs.protocol, list):
+                fs.protocol = split[0]
+        return fs, split[1]
+
+
+def _single_file_copy(src_fs, src_path, dest_fs, dest_path,
+                      buffer_size=CHUNK_SIZE, size_hint=None,
+                      max_concurrent_copies=MAX_CONCURRENT_COPIES):
+    if dest_path.split('/')[-1] == '.gitattributes':
+        print("Skipping .gitattributes as that is required for Xet Magic")
+        return
+    print(f"Copying {src_path} to {dest_path}...")
+
+    if src_fs.protocol == 'xet' and dest_fs.protocol == 'xet':
+        dest_fs.cp_file(src_path, dest_path)
+        return
+    with max_concurrent_copies:
+        try:
+            if dest_fs.protocol == "xet":
+                if size_hint is None:
+                    size_hint = src_fs.info(src_path).get('size', None)
+
+                # Heuristic for now -- if the size of the source is larger than 50MB,
+                # then make sure we have any shards for the destination that work.
+                if size_hint is not None and size_hint >= 50000000:
+                    dest_fs.add_deduplication_hints(dest_path)
+
+            with src_fs.open(src_path, "rb") as source_file:
+                with dest_fs.open(dest_path, "wb", auto_mkdir=True) as dest_file:
+                    # Buffered copy in chunks
+                    while True:
+                        chunk = source_file.read(buffer_size)
+                        if not chunk:
+                            break
+                        dest_file.write(chunk)
+        except Exception as e:
+            proto = src_fs.protocol
+            print(f"Failed to copy {proto}://{src_path}: {e}")
+
+
+def _validate_xet_copy(src_fs, src_path, dest_fs, dest_path):
+    """
+    Performs some basic early validation of a xet to avoid issues later.
+    Does not catch all failure conditions, but catches some early enough to
+    avoid doing a lot of unnecessary work, then fail.
+
+    Raises an exception on failure, returns True on success
+    """
+    srcproto = src_fs.protocol
+    destproto = dest_fs.protocol
+    # if src is a xet, there must be a branch to copy from
+    if srcproto == 'xet':
+        src_fs.branch_info(src_path)
+
+    if destproto == 'xet':
+        # check dest branch exists
+        # exists before we try to do any copying
+        # An exception is that if this operation would create a branch
+        if srcproto == 'xet':
+            src_parse = parse_url(src_path, src_fs.domain)
+            dest_parse = parse_url(dest_path, dest_fs.domain)
+            if src_parse.path == '' and dest_parse.path == '':
+                # this is a branch to branch copy
+                return True
+
+        dest_fs.branch_info(dest_path)
+
+
+def _isdir(fs, path):
+    if fs.protocol == 'xet':
+        return fs.isdir_or_branch(path)
+    else:
+        return fs.isdir(path)
+
+
+def _copy(source: str, destination: str, recursive: bool = True,
+          _src_fs: fsspec.spec.AbstractFileSystem = None,
+          _dest_fs: fsspec.spec.AbstractFileSystem = None,
+          max_concurrent_copies: threading.Semaphore = MAX_CONCURRENT_COPIES):
+    src_fs, src_path = _get_fs_and_path(source)
+    dest_fs, dest_path = _get_fs_and_path(destination)
+    if _src_fs is not None:
+        src_fs = _src_fs
+    if _dest_fs is not None:
+        dest_fs = _dest_fs
+    srcproto = src_fs.protocol
+    destproto = dest_fs.protocol
+
+    _validate_xet_copy(src_fs, src_path, dest_fs, dest_path)
+
+    # normalize trailing '/' by just removing them unless the path
+    # is exactly just '/'
+    if src_path != '/':
+        src_path = src_path.rstrip('/')
+    if dest_path != '/':
+        dest_path = dest_path.rstrip('/')
+    src_isdir = _isdir(src_fs, src_path)
+
+    # Handling wildcard cases
+    if '*' in src_path:
+        # validate
+        # we only accept globs of the for blah/blah/blah/[glob]
+        # i.e. the glob is only in the last component
+        # src_root_dir should be blah/blah/blah here
+        src_root_dir = '/'.join(src_path.split('/')[:-1])
+        if '*' in src_root_dir:
+            raise ValueError(f"Invalid glob {source}. Wildcards can only appear in the last position")
+        # The source path contains a wildcard
+        with ThreadPoolExecutor() as executor:
+            futures = []
+            for path, info in src_fs.glob(src_path, detail=True).items():
+                # Copy each matching file
+                if info['type'] == 'directory' and not recursive:
+                    continue
+                relpath = _ltrim_match(path, src_root_dir).lstrip('/')
+                if dest_path == '/':
+                    dest_for_this_path = f"/{relpath}"
+                else:
+                    dest_for_this_path = f"{dest_path}/{relpath}"
+                dest_dir = '/'.join(dest_for_this_path.split('/')[:-1])
+                dest_fs.makedirs(dest_dir, exist_ok=True)
+
+                if info['type'] == 'directory':
+                    futures.append(
+                        executor.submit(
+                            _copy,
+                            f"{src_fs.protocol}://{path}",
+                            f"{dest_fs.protocol}://{dest_for_this_path}",
+                            recursive=True,
+                            _src_fs=src_fs,
+                            _dest_fs=dest_fs,
+                        )
+                    )
+                else:
+                    futures.append(
+                        executor.submit(
+                            _single_file_copy,
+                            src_fs,
+                            f"{path}",
+                            dest_fs,
+                            dest_for_this_path,
+                            size_hint=info.get('size', None)
+                        ))
+
+            for future in futures:
+                future.result()
+        return
+
+    # Handling directories
+    if src_isdir:
+        # Recursively copy
+        # xet cp_file can cp directories
+        if srcproto == 'xet' and destproto == 'xet':
+            print(f"Copying {src_path} to {dest_path}...")
+            dest_fs.cp_file(src_path, dest_path)
+            return
+        with ThreadPoolExecutor() as executor:
+            futures = []
+            for path, info in src_fs.find(src_path, detail=True).items():
+                if info['type'] == 'directory' and not recursive:
+                    continue
+                # Note that path is a full path
+                # we need to relativize to make the destination path
+                relpath = _ltrim_match(path, src_path).lstrip('/')
+                if dest_path == '/':
+                    dest_for_this_path = f"/{relpath}"
+                else:
+                    dest_for_this_path = f"{dest_path}/{relpath}"
+                dest_dir = '/'.join(dest_for_this_path.split('/')[:-1])
+                dest_fs.makedirs(dest_dir, exist_ok=True)
+                # Submitting copy jobs to thread pool
+                futures.append(
+                    executor.submit(
+                        _single_file_copy,
+                        src_fs,
+                        f"{path}",
+                        dest_fs,
+                        dest_for_this_path,
+                        size_hint=info.get('size', None)
+                    ))
+            # Waiting for all copy jobs to complete
+            for future in futures:
+                future.result()
+        return
+
+    _single_file_copy(src_fs, src_path, dest_fs, dest_path, max_concurrent_copies=max_concurrent_copies)
+
+
+def _mv(source: str, target: str, recursive: bool, message: str):
+    if not message:
+        message = f"move {source} to {target}" if not recursive else f"move {source} to {target} recursively"
+    src_fs, src_path = _get_fs_and_path(source)
+    dest_fs, dest_path = _get_fs_and_path(target)
+    if src_fs.protocol != dest_fs.protocol:
+        print(
+            "Unable to move between different protocols {src_fs.protocol}, {dest_fs.protocol}\nYou may want to copy instead",
+            file=sys.stderr)
+    destproto_is_xet = dest_fs.protocol == 'xet'
+    try:
+        if destproto_is_xet:
+            dest_fs.start_transaction(message)
+        dest_fs.mv(src_path, dest_path)
+        if destproto_is_xet:
+            dest_fs.end_transaction()
+    except Exception as e:
+        print(f"{e}")
+        return
+
+
+def _rm(paths=typing.List[str], message=str):
+    if not message:
+        message = f"delete {paths}"
+    fs, _ = _get_fs_and_path(paths[0])
+    try:
+        destproto_is_xet = fs.protocol == 'xet'
+        if destproto_is_xet:
+            for path in paths:
+                parsed_path = parse_url(path, fs.domain)
+                if len(parsed_path.path) == 0 and len(parsed_path.branch) > 0:
+                    print(
+                        "Cannot delete branches with 'rm' as this is a non-reversible operation and history will not be preserved. Use 'xet branch del'",
+                        file=sys.stderr)
+                    return
+            fs.start_transaction(message)
+        for path in paths:
+            fs.rm(path)
+        if destproto_is_xet:
+            fs.end_transaction()
+    except Exception as e:
+        print(f"{e}")
+        return
+
+
+def _info(uri: str):
+    fs, path = _get_fs_and_path(uri)
+    return fs.info(path)
+
+
+def _duplicate(source: str = None,
+               dest: str = None,
+               private: bool = False,
+               public: bool = False,
+               verbose: bool = False):
+    fs = XetFS()
+    if dest is None:
+        repo_name = source.rstrip('/').split('/')[-1]
+        dest = "xet://" + fs.get_username() + "/" + repo_name
+        if verbose:
+            print(f"Duplicating to {dest}")
+    else:
+        repo_name = source.rstrip('/').split('/')[-1]
+    fs.duplicate_repo(source, dest)
+    try:
+        if private:
+            if verbose:
+                print(f"Duplicate Success. Changing permissions...")
+            fs.set_repo_attr(dest, "private", True)
+            if verbose:
+                print(f"Repo permissions set successfully")
+        if public:
+            if verbose:
+                print(f"Duplicate Success. Changing permissions...")
+            fs.set_repo_attr(dest, "public", False)
+            if verbose:
+                print(f"Repo permissions set successfully")
+    except Exception as e:
+        username = fs.get_username()
+        if verbose:
+            print(f"An error has occurred setting repository permissions: {e}")
+            print("Permission changes may not have been made. Please change it manually at:")
+            print(f"  {fs.domain}/{username}/{repo_name}/settings")
+
+
+def _root_copy(source, destination, message, recursive=False, max_concurrent_copies=MAX_CONCURRENT_COPIES):
+    dest_fs, dest_path = _get_fs_and_path(destination)
+    destproto_is_xet = dest_fs.protocol == 'xet'
+    dest_isdir = _isdir(dest_fs, dest_path)
+
+    # Our target is an existing directory and src is not a wildcard copy
+    # i.e. we are getting cp src/some/path to dest/some/where
+    # but dest/some/where exists as a directory
+    # So we will need to make the dest dest/some/where/path
+    if dest_isdir and '*' not in source:
+        # split up the final component from source path and add it
+        # to the destination
+        final_source_component = source.split('/')[-1]
+        if not destination.endswith('/'):
+            destination += '/'
+        destination += final_source_component
+
+    if destproto_is_xet:
+        dest_fs.start_transaction(message)
+    _copy(source, destination, recursive, max_concurrent_copies=max_concurrent_copies)
+    if destproto_is_xet:
+        dest_fs.end_transaction()
+
+
+def configure_login(email: str, user: str, password: str, host: str = "xethub.com", force: bool = False,
+                    no_overwrite: bool = False):
+    """
+    Configures the login information. Stores the config in ~/.xetconfig
+
+    Parameters
+    ----------
+    email [str]: email address associated with account
+    user [str]: user name
+    password [str]: password
+    host [str]: host to authenticate against (default: xethub.com)
+    force [bool]: do not perform authentication check and force write to config
+    no_overwrite [bool]: Do not overwrite if existing auth information is found
+
+    Returns
+    -------
+
+    """
+    return rpyxet.configure_login(host, user, email, password, force, no_overwrite)
+
+
+def perform_mount(remote, path, branch, prefetch):
+    return rpyxet.perform_mount(sys.executable, remote, path, branch, prefetch)
+
+
+def perform_mount_curdir(path, reference, signal, autostop, prefetch, ip, writable):
+    return rpyxet.perform_mount_curdir(path=path,
+                                       reference=reference,
+                                       signal=signal,
+                                       autostop=autostop,
+                                       prefetch=prefetch,
+                                       ip=ip,
+                                       writable=writable)

--- a/python/pyxet/pyxet/core.py
+++ b/python/pyxet/pyxet/core.py
@@ -518,12 +518,13 @@ def _clone(source: str, *args):
     Returns
     -------
     """
+
     fs = XetFS()
     source = parse_url(source, fs.domain)
-    commands = ["git-xet", "clone"] + [source.remote] + args
+    commands = ["git-xet", "clone"] + [source.remote] + list(args)
     strcommand = ' '.join(commands)
     print(f"Running '{strcommand}'")
-    subprocess.run(["git-xet", "clone"] + [source.remote] + args)
+    subprocess.run(strcommand, shell=True)
 
 
 def clone(source: str, *args):

--- a/python/pyxet/pyxet/core.py
+++ b/python/pyxet/pyxet/core.py
@@ -412,34 +412,34 @@ def _perform_mount_curdir(path, reference, signal, autostop, prefetch, ip, writa
                                         writable=writable)
 
 
-def _make_branch(repo: str,
-                 src_branch: str,
-                 dest_branch: str):
+def make_branch(repo: str,
+                src_branch: str,
+                dest_branch: str):
     fs, remote = _get_fs_and_path(repo)
     assert (fs.protocol == XET)
     assert ('/' not in dest_branch)
     fs.make_branch(remote, src_branch, dest_branch)
 
 
-def _list_branches(repo: str, raw: bool = False):
+def list_branches(repo: str, raw: bool = False):
     fs, path = _get_fs_and_path(repo)
     assert (fs.protocol == XET)
     return fs.list_branches(repo, raw)
 
 
-def _delete_branch(repo: str, branch: str):
+def delete_branch(repo: str, branch: str):
     fs, path = _get_fs_and_path(repo)
     assert (fs.protocol == XET)
     return fs.delete_branch(repo, branch)
 
 
-def _info_branch(repo: str, branch: str):
+def get_branch_info(repo: str, branch: str):
     fs, path = _get_fs_and_path(repo)
     assert (fs.protocol == XET)
     return fs.find_ref(repo, branch)
 
 
-def _make_repo(name: str, private: bool = False, public: bool = False):
+def make_repo(name: str, private: bool = False, public: bool = False):
     if private == public:
         raise ValueError("One of --private or --public must be set")
     fs = XetFS()
@@ -449,7 +449,7 @@ def _make_repo(name: str, private: bool = False, public: bool = False):
     return ret
 
 
-def _fork_repo(source: str, dest: str = None) -> dict:
+def fork_repo(source: str, dest: str = None) -> dict:
     """
             Forks a copy of a repository from xet://[user]/[repo] to your own account.
             Defaults to original repository private/public settings.
@@ -463,7 +463,7 @@ def _fork_repo(source: str, dest: str = None) -> dict:
     fs.fork_repo(source, dest)
 
 
-def _list_repos(raw: bool = False) -> typing.List[typing.Union[dict, str]]:
+def list_repos(raw: bool = False) -> typing.List[typing.Union[dict, str]]:
     """
     Lists all repositories
     Parameters
@@ -478,7 +478,7 @@ def _list_repos(raw: bool = False) -> typing.List[typing.Union[dict, str]]:
     return fs.list_repos(raw)
 
 
-def _rename_repo(source: str, dest: str):
+def rename_repo(source: str, dest: str):
     """
     Renames a repository
     Parameters

--- a/python/pyxet/pyxet/core.py
+++ b/python/pyxet/pyxet/core.py
@@ -363,15 +363,40 @@ def configure_login(email: str, user: str, password: str, host: str = "xethub.co
     return rpyxet.configure_login(host, user, email, password, force, no_overwrite)
 
 
-def perform_mount(remote, path, branch, prefetch):
-    return rpyxet.perform_mount(sys.executable, remote, path, branch, prefetch)
+def _mount(source: str, path: str, prefetch: int = 2):
+    """
+    Mounts a repository on a local path
+
+    Parameters
+    ----------
+    source [str]: Repository and branch of the form xet://user/repo/branch"
+    path [str]: Path to mount to. (or a drive letter on windows)
+    prefetch [int]: Prefetch blocks in multiple of 16MB. Default=2
+
+    Returns
+    -------
+
+    """
+    fs = XetFS()
+    source = parse_url(source, fs.domain)
+    if source.path != '':
+        raise ValueError("Cannot have a path when mounting. Expecting only xet://user/repo/branch")
+    if source.branch == '':
+        raise ValueError("Branch or revision must be specified")
+    if os.name == 'nt':
+        # path must be a drive letter (X, or X: or X:\\)
+        letter = path[0]
+        if path != letter and path != letter + ':' and path != letter + ':\\':
+            raise ValueError("Path must be a drive letter of the form X:")
+        path = letter
+    rpyxet.perform_mount(sys.executable, source.remote, path, source.branch, prefetch)
 
 
-def perform_mount_curdir(path, reference, signal, autostop, prefetch, ip, writable):
-    return rpyxet.perform_mount_curdir(path=path,
-                                       reference=reference,
-                                       signal=signal,
-                                       autostop=autostop,
-                                       prefetch=prefetch,
-                                       ip=ip,
-                                       writable=writable)
+def _perform_mount_curdir(path, reference, signal, autostop, prefetch, ip, writable):
+    return rpyxet._perform_mount_curdir(path=path,
+                                        reference=reference,
+                                        signal=signal,
+                                        autostop=autostop,
+                                        prefetch=prefetch,
+                                        ip=ip,
+                                        writable=writable)


### PR DESCRIPTION
In an effort to make some of pyxet functionalities more accessible through python instead if CLI,
I have moved all functionalities to a `pyxet/core.py`, and the CLI just call it from there.

This let us use all the functionalities straight from pyxet like so:
```
pyxet.cli.PyxetCLI.cp() → pyxet.cp()
```

Although by itself it's a lot of work for a small alias, this also opens the door to future functionalities and automations from the python side.