### PR TITLE
Check empty user name

### DIFF
--- a/python/pyxet/pyxet/cli.py
+++ b/python/pyxet/pyxet/cli.py
@@ -487,7 +487,11 @@ class PyxetCLI:
         fs = XetFS()
         if dest is None:
             repo_name = source.rstrip('/').split('/')[-1]
-            dest = "xet://" + fs.get_username() + "/" + repo_name
+            username = fs.get_username().strip()
+            if not bool(username):
+                print("Failed to infer a user name to duplicate the repo, please provide a full dest name")
+                return
+            dest = "xet://" + username + "/" + repo_name
             print(f"Duplicating to {dest}")
         else:
             repo_name = source.rstrip('/').split('/')[-1]

--- a/python/pyxet/pyxet/cli.py
+++ b/python/pyxet/pyxet/cli.py
@@ -489,7 +489,7 @@ class PyxetCLI:
             repo_name = source.rstrip('/').split('/')[-1]
             username = fs.get_username().strip()
             if not bool(username):
-                print("Failed to infer a user name to duplicate the repo, please provide a full dest name")
+                print("Failed to infer a user name to duplicate the repo, please provide a full target name")
                 return
             dest = "xet://" + username + "/" + repo_name
             print(f"Duplicating to {dest}")


### PR DESCRIPTION
On duplicate command check if able to infer a valid user name and if not prompt user to specify a full dest name.
Fix https://github.com/xetdata/xethub/issues/3761