### PR TITLE
Improved ls output

### DIFF
--- a/python/pyxet/pyxet/cli.py
+++ b/python/pyxet/pyxet/cli.py
@@ -374,6 +374,9 @@ class PyxetCLI:
             if raw:
                 print(listing)
             else:
+                if fs.protocol == 'xet':
+                    for entry in listing:
+                        entry['name'] = 'xet://' + entry['name']
                 print(tabulate(listing, headers="keys"))
             return listing
         except Exception as e:
@@ -643,7 +646,7 @@ class RepoCLI:
                 print(repos)
             else:
                 print(tabulate(repos, headers="keys"))
-            return ls
+            return repos
         except Exception as e:
             print(f"{e}")
             return

--- a/python/pyxet/pyxet/cli.py
+++ b/python/pyxet/pyxet/cli.py
@@ -368,6 +368,7 @@ class PyxetCLI:
     def ls(path: Annotated[str, typer.Argument(help="Source file or folder which will be copied")] = "xet://",
            raw: Annotated[bool, typer.Option(help="If True, will print the raw JSON output")] = False):
         """list files and folders"""
+        original_path = path
         fs, path = _get_fs_and_path(path)
         try:
             listing = fs.ls(path, detail=True)
@@ -380,6 +381,9 @@ class PyxetCLI:
                 print(tabulate(listing, headers="keys"))
             return listing
         except Exception as e:
+            # this failed to list. retry as a file
+            if fs.protocol == 'xet':
+                return PyxetCLI.info(original_path, raw)
             print(f"{e}")
             return
 
@@ -467,7 +471,9 @@ class PyxetCLI:
             if raw:
                 print(info)
             else:
-                print(tabulate([info]))
+                if fs.protocol == 'xet':
+                    info['name'] = 'xet://' + info['name']
+                print(tabulate([info], headers="keys"))
             return info
         except Exception as e:
             print(f"{e}")

--- a/python/pyxet/pyxet/file_system.py
+++ b/python/pyxet/pyxet/file_system.py
@@ -373,7 +373,8 @@ class XetFS(fsspec.spec.AbstractFileSystem):
         url_path = parse_url(path, self.domain)
 
         if url_path.branch == '':
-            return self.list_branches(path)
+            branches = self.list_branches(path)
+            return [{'name':path + '/' + n['name'], 'type':'branch'} for n in branches]
 
 
         parse = urlparse(url_path.remote)


### PR DESCRIPTION
 - Fixed issue where branch printing does not list the repo, (it just outputs branch name instead of [user]/[repo]/branch)
 - Prepended xet:// to every ls output so that you can just copy and paste entries directly.
 - allow 'ls' to work on individual files