### PR TITLE
only load aws creds when available

### DIFF
--- a/python/pyxet/pyproject.toml
+++ b/python/pyxet/pyproject.toml
@@ -40,6 +40,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence"
 ]
 dependencies = [
+    "boto3>=1.28.0",
     "fsspec>=2023.4.0",
     "typer>=0.9.0",
     "tabulate>=0.9.0",


### PR DESCRIPTION
Loads AWS credentials on s3 access via xet cli iff they are available.

Implies credentials will be loaded if available for both public and private bucket access, not loaded but operation should succeed for public buckets if there aren't any credentials, but fail with no credentials with private bucket with a botocore `PermissionError: Access Denied`.

Enables public s3 bucket access with no credentials.