### PR TITLE
Allow pyxet docs to be buildable without the rust build.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,9 +1,11 @@
 import os
 import sys
 
+os.environ['SPHINX_BUILD'] = "1"
 sys.path.insert(0, os.path.abspath('../python/pyxet'))
 
 import pyxet
+
 # Configuration file for the Sphinx documentation builder.
 #
 # For the full list of built-in configuration values, see the documentation:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,6 @@ myst-parser
 Sphinx
 sphinx-rtd-theme
 sphinx-book-theme==0.3.3
-fsspec
 boto3
 fsspec
 typer

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,9 @@ myst-parser
 Sphinx
 sphinx-rtd-theme
 sphinx-book-theme==0.3.3
+fsspec
+boto3
+fsspec
+typer
+tabulate
+s3fs

--- a/python/pyxet/pyxet/cli.py
+++ b/python/pyxet/pyxet/cli.py
@@ -12,9 +12,11 @@ import typing
 from tabulate import tabulate
 from .file_system import XetFS
 from .url_parsing import parse_url
-from .rpyxet import rpyxet
 from .version import __version__
 import subprocess
+
+if 'SPHINX_BUILD' not in os.environ:
+    from .rpyxet import rpyxet
 
 cli = typer.Typer(add_completion=True, short_help="a pyxet command line interface", no_args_is_help=True)
 repo = typer.Typer(add_completion=False, short_help="sub-commands to manage repositories")

--- a/python/pyxet/pyxet/file_system.py
+++ b/python/pyxet/pyxet/file_system.py
@@ -3,13 +3,15 @@ import sys
 from urllib.parse import urlparse
 
 import fsspec
+import os
 
 from .commit_transaction import MultiCommitTransaction
 from .file_interface import XetFile
-from .rpyxet import rpyxet
 from .url_parsing import parse_url, XetPathInfo
 
-_manager = rpyxet.PyRepoManager()
+if 'SPHINX_BUILD' not in os.environ:
+    from .rpyxet import rpyxet
+    _manager = rpyxet.PyRepoManager()
 
 
 def login(user, token, email=None, host=None):


### PR DESCRIPTION
We do not import rpyxet if the the SPHINX_BUILD environment variable is set.