### PR TITLE
refactor copy logic to build a copy list first

### DIFF
--- a/python/pyxet/pyxet/util.py
+++ b/python/pyxet/pyxet/util.py
@@ -159,7 +159,6 @@ def _path_join(fs, path, *paths):
     if fs.protocol == 'file':
         return os.path.join(path, *paths)
     else:
-        #return '/'.join([path] + list(map(lambda p: p.strip('/'), paths)))
         return '/'.join([path] + [p.strip('/') for p in paths if len(p) != 0])
 
 
@@ -194,9 +193,7 @@ def _parse_and_sanitize_src_and_dest_path(source, destination):
         # '/' or '\', the desired behavior is to copy what's 
         # under that directory, and to skip 'source' itself.
         _, final_source_component = _path_split(src_fs, source)
-        print(f"++ {final_source_component}, {dest_path}")
         dest_path = _path_join(dest_fs, dest_path, final_source_component)
-        print(f"+++ {dest_path}")
     return src_fs, src_path, dest_fs, dest_path
 
 def _build_src_and_dest_list(source, destination, recursive=False, _src_fs=None, _dest_fs=None):
@@ -264,7 +261,6 @@ def _build_src_and_dest_list(source, destination, recursive=False, _src_fs=None,
                     relpath = relpath.replace(os.sep, posixpath.sep)
                 dest_for_this_path = _path_join(dest_fs, dest_path, relpath)
                 dest_dir = _path_dirname(dest_fs, dest_for_this_path)
-                print(f"+ {dest_path}, {relpath}, {dest_for_this_path}, {dest_dir}, {info.get('size', None)}")
                 cplist.append(CopyUnit(path, dest_for_this_path, dest_dir, info.get('size', None)))
         return src_fs, dest_fs, cplist
     
@@ -272,7 +268,7 @@ def _build_src_and_dest_list(source, destination, recursive=False, _src_fs=None,
     cplist.append(CopyUnit(src_path, dest_path, "", 0))
     return src_fs, dest_fs, cplist
 
-def _copy2(source, destination, recursive=False):
+def _copy(source, destination, recursive=False):
     src_fs, dest_fs, cplist = _build_src_and_dest_list(source, destination, recursive)
     # xet -> xet copy already handled
     # directory copy with recursive=False filtered out
@@ -295,115 +291,6 @@ def _copy2(source, destination, recursive=False):
         for future in futures:
             future.result()
 
-def _copy(source, destination, recursive=True, _src_fs=None, _dest_fs=None):
-    src_fs, src_path = _get_fs_and_path(source)
-    dest_fs, dest_path = _get_fs_and_path(destination)
-    if _src_fs is not None:
-        src_fs = _src_fs
-    if _dest_fs is not None:
-        dest_fs = _dest_fs
-    srcproto = src_fs.protocol
-    destproto = dest_fs.protocol
-
-    _validate_xet_copy(src_fs, src_path, dest_fs, dest_path)
-
-    # normalize trailing '/' by just removing them unless the path
-    # is exactly just '/'
-    if src_path != '/':
-        src_path = src_path.rstrip('/')
-    if dest_path != '/':
-        dest_path = dest_path.rstrip('/')
-    src_isdir = _isdir(src_fs, src_path)
-
-    # Handling wildcard cases
-    if '*' in src_path:
-        # validate
-        # we only accept globs of the for blah/blah/blah/[glob]
-        # i.e. the glob is only in the last component
-        # src_root_dir should be blah/blah/blah here
-        src_root_dir, _ = _path_split(src_fs, src_path)
-        if '*' in src_root_dir:
-            raise ValueError(f"Invalid glob {source}. Wildcards can only appear in the last position")
-        # The source path contains a wildcard
-        with ThreadPoolExecutor() as executor:
-            futures = []
-            for path, info in src_fs.glob(src_path, detail=True).items():
-                # Copy each matching file
-                if info['type'] == 'directory' and not recursive:
-                    continue
-                relpath = _rel_path(path, src_root_dir)
-                if src_fs.protocol == 'file' and os.sep != posixpath.sep:
-                    relpath = relpath.replace(os.sep, posixpath.sep)
-                dest_for_this_path = _path_join(dest_fs, dest_path, relpath)
-                dest_dir = _path_dirname(dest_fs, dest_for_this_path)
-                dest_fs.makedirs(dest_dir, exist_ok=True)
-
-                if info['type'] == 'directory':
-                    futures.append(
-                        executor.submit(
-                            _copy,
-                            f"{src_fs.protocol}://{path}",
-                            f"{dest_fs.protocol}://{dest_for_this_path}",
-                            recursive=True,
-                            _src_fs=src_fs,
-                            _dest_fs=dest_fs,
-                        )
-                    )
-                else:
-                    futures.append(
-                        executor.submit(
-                            _single_file_copy,
-                            src_fs,
-                            f"{path}",
-                            dest_fs,
-                            dest_for_this_path,
-                            size_hint=info.get('size', None)
-                        ))
-
-            for future in futures:
-                future.result()
-        return
-
-    # Handling directories
-    if src_isdir:
-        # Recursively copy
-        # xet cp_file can cp directories
-        if srcproto == 'xet' and destproto == 'xet':
-            print(f"Copying {src_path} to {dest_path}...")
-            dest_fs.cp_file(src_path, dest_path)
-            return
-        with ThreadPoolExecutor() as executor:
-            futures = []
-            for path, info in src_fs.find(src_path, detail=True).items():
-                if info['type'] == 'directory' and not recursive:
-                    continue
-                # Note that path is a full path
-                # we need to relativize to make the destination path
-                relpath = _rel_path(path, src_path)
-                if src_fs.protocol == 'file' and os.sep != posixpath.sep:
-                    relpath = relpath.replace(os.sep, posixpath.sep)
-                dest_for_this_path = _path_join(dest_fs, dest_path, relpath)
-                dest_dir = _path_dirname(dest_fs, dest_for_this_path)
-                dest_fs.makedirs(dest_dir, exist_ok=True)
-
-                # Submitting copy jobs to thread pool
-                futures.append(
-                    executor.submit(
-                        _single_file_copy,
-                        src_fs,
-                        f"{path}",
-                        dest_fs,
-                        dest_for_this_path,
-                        size_hint=info.get('size', None)
-                    ))
-            # Waiting for all copy jobs to complete
-            for future in futures:
-                future.result()
-        return
-
-    _single_file_copy(src_fs, src_path, dest_fs, dest_path)
-
-
 def _root_copy(source, destination, message, recursive=False, do_not_commit=False):
     dest_fs, dest_path = _get_fs_and_path(destination)
     destproto_is_xet = dest_fs.protocol == 'xet'
@@ -412,6 +299,6 @@ def _root_copy(source, destination, message, recursive=False, do_not_commit=Fals
         tr = dest_fs.start_transaction(message)
         if do_not_commit:
             tr._set_do_not_commit()
-    _copy2(source, destination, recursive)
+    _copy(source, destination, recursive)
     if destproto_is_xet:
         dest_fs.end_transaction()

--- a/python/pyxet/tests/cli_cp_test.py
+++ b/python/pyxet/tests/cli_cp_test.py
@@ -5,7 +5,7 @@ import utils
 import shutil
 import tempfile
 
-from pyxet.util import _root_copy
+from pyxet.util import _root_copy, _build_src_and_dest_list
 
 
 def test_single_file_upload():
@@ -345,3 +345,21 @@ def test_large_batch_upload():
 
     finally:
         pyxet.BranchCLI.delete(f"xet://{user}/{repo}", b1, True)
+
+def test_size_hint():
+    user = utils.test_account_login()
+    repo = utils.test_repo()
+
+    try:
+        # generate a large batch of random files in a temp dir
+        dir = tempfile.mkdtemp()
+        local_files = [f"{dir}/data0", f"{dir}/data1"]
+        utils.random_binary_files(local_files, [1024, 1024])
+
+        _, _, cplist = _build_src_and_dest_list(f"{dir}/*", f"xet://{user}/{repo}/main")
+        assert len(cplist) > 0
+        for cp in cplist:
+            assert cp.size == 1024
+
+    finally:
+        shutil.rmtree(dir)

--- a/python/pyxet/tests/cli_cp_test.py
+++ b/python/pyxet/tests/cli_cp_test.py
@@ -183,7 +183,6 @@ def test_glob_recursive_upload():
     finally:
         pyxet.BranchCLI.delete(f"xet://{user}/{repo}", b1, True)
     
-@pytest.mark.skip(reason="fix in a future PR")
 def test_directory_nonrecursive_upload():
     user = utils.test_account_login()
     repo = utils.test_repo()

--- a/python/pyxet/tests/cli_cp_test.py
+++ b/python/pyxet/tests/cli_cp_test.py
@@ -354,12 +354,12 @@ def test_size_hint():
         # generate a large batch of random files in a temp dir
         dir = tempfile.mkdtemp()
         local_files = [f"{dir}/data0", f"{dir}/data1"]
-        utils.random_binary_files(local_files, [1024, 1024])
+        utils.random_binary_files(local_files, [262, 471])
 
         _, _, cplist = _build_src_and_dest_list(f"{dir}/*", f"xet://{user}/{repo}/main")
-        assert len(cplist) > 0
-        for cp in cplist:
-            assert cp.size == 1024
+        assert len(cplist) == 2
+        assert cplist[0].size == 262
+        assert cplist[1].size == 471
 
     finally:
         shutil.rmtree(dir)


### PR DESCRIPTION
Refactors the copy logic to build a copy list before executing copy between local FS and xet FS, each entry in the list contains src_path, dest_path, and the bytes to copy. This lays the foundation for hint shard batch prefetch and progress bar.

Also fixed a bug that xet cp directory without `-r` would work. All tests enabled and passed.