### PR TITLE
fix fsspec test due to fsspec upgrade

### DIFF
--- a/python/pyxet/tests/fsspec_test.py
+++ b/python/pyxet/tests/fsspec_test.py
@@ -23,8 +23,8 @@ def test_fsspec():
 
     listing = fs.glob(CONSTANTS.TITANIC_MAIN + '/data/')
     print(listing)
-    assert len(listing) == 2
-    assert listing == ['xdssio/titanic/main/data/titanic_0.parquet', 'xdssio/titanic/main/data/titanic_1.parquet']
+    assert len(listing) == 1
+    assert listing == ['xdssio/titanic/main/data/']
 
     listing = fs.glob(CONSTANTS.TITANIC_MAIN + '/data/*')
     print(listing)
@@ -48,8 +48,8 @@ def test_fsspec():
 
     listing = fs.glob(CONSTANTS.TITANIC_MAIN + '/**/*parquet')
     print(listing)
-    assert len(listing) == 2
-    assert listing == ['xdssio/titanic/main/data/titanic_0.parquet', 'xdssio/titanic/main/data/titanic_1.parquet']
+    assert len(listing) == 3
+    assert listing == ['xdssio/titanic/main/data/titanic_0.parquet', 'xdssio/titanic/main/data/titanic_1.parquet', 'xdssio/titanic/main/titanic.parquet']
 
     listing = fs.glob(CONSTANTS.TITANIC_MAIN + '/titanic*')
     print(listing)


### PR DESCRIPTION
`fsspec` upgrade in https://github.com/fsspec/filesystem_spec/pull/1329 makes
1. when using a trailing slash in globs, it returns only directories.
2. the double asterisks ** matches 0+ directories.

This PR fix the tests accordingly.