### PR TITLE
Reduce transaction limits to prevent 504 errors.

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -56,4 +56,4 @@ jobs:
           Get-ChildItem "target/wheels" -Filter pyxet*.whl | Foreach-Object {
             pip install $_.FullName
           }
-          pytest tests
+          python -m pytest tests

--- a/python/pyxet/pyxet/commit_transaction.py
+++ b/python/pyxet/pyxet/commit_transaction.py
@@ -5,7 +5,7 @@ import fsspec
 
 from .file_interface import XetFile
 
-TRANSACTION_FILE_LIMIT = 2048
+TRANSACTION_FILE_LIMIT = 512
 
 
 def _validate_repo_info_for_transaction(repo_info):

--- a/python/pyxet/src/transactions.rs
+++ b/python/pyxet/src/transactions.rs
@@ -9,7 +9,7 @@ use xetblob::*;
 
 lazy_static! {
     // Set this to a larger number now; reduce if there are issues.
-    static ref MAX_NUM_CONCURRENT_TRANSACTIONS: AtomicUsize = AtomicUsize::new(8);
+    static ref MAX_NUM_CONCURRENT_TRANSACTIONS: AtomicUsize = AtomicUsize::new(3);
 
     static ref TRANSACTION_LIMIT_LOCK: Arc<Semaphore> = Arc::new(Semaphore::new((*MAX_NUM_CONCURRENT_TRANSACTIONS).load(Ordering::Relaxed)));
 }


### PR DESCRIPTION
   Currently, the transaction limits allow 2048 files per commit, and 8
    commits to be in flight at once.  However, analysis of the atomic_commit
    function, called to complete a transaction, show that this operation
    takes roughly 100-150ms per file present in the transaction.  This
    results in the client-side piling up transactions on the server, with
    the commits later in the queue not completing before the load balancer
    times out.  Reducing these limits is a temporary fix to throttle the
    number of commits while still allowing CAS and other file uploads to
    proceed in parallel.
