### PR TITLE
Add flag to update the source bucket size on Xetea

### DIFF
--- a/python/pyxet/pyproject.toml
+++ b/python/pyxet/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence"
 ]
 dependencies = [
-    "fsspec>=2023.9.0",
+    "fsspec==2023.9.2",
     "typer>=0.9.0",
     "tabulate>=0.9.0",
     "s3fs>=2023.6.0"

--- a/python/pyxet/pyxet/cli.py
+++ b/python/pyxet/pyxet/cli.py
@@ -135,7 +135,7 @@ class PyxetCLI:
              target: Annotated[str, typer.Argument(help="Target location of the folder")],
              use_mtime: Annotated[bool, typer.Option("--use-mtime", help="Use mtime as criteria for sync")] = False,
              message: Annotated[str, typer.Option("--message", "-m", help="A commit message")] = "",
-             update_size: Annotated[bool, typer.Option("--update-size", hidden=True)] = False,
+             update_size: Annotated[bool, typer.Option("--update-size", hidden=True, help="Update Xetea with the size of the remote bucket")] = False,
              parallel: Annotated[int, typer.Option("--parallel", "-p", help="Maximum amount of parallelism")] = 32,
              dryrun: Annotated[
                  bool, typer.Option("--dryrun",

--- a/python/pyxet/pyxet/cli.py
+++ b/python/pyxet/pyxet/cli.py
@@ -135,6 +135,7 @@ class PyxetCLI:
              target: Annotated[str, typer.Argument(help="Target location of the folder")],
              use_mtime: Annotated[bool, typer.Option("--use-mtime", help="Use mtime as criteria for sync")] = False,
              message: Annotated[str, typer.Option("--message", "-m", help="A commit message")] = "",
+             update_size: Annotated[bool, typer.Option("--update-size", hidden=True)] = False,
              parallel: Annotated[int, typer.Option("--parallel", "-p", help="Maximum amount of parallelism")] = 32,
              dryrun: Annotated[
                  bool, typer.Option("--dryrun",
@@ -143,7 +144,7 @@ class PyxetCLI:
         if not message:
             message = f"sync {source} to {target}"
         util.MAX_CONCURRENT_COPIES = threading.Semaphore(parallel)
-        cmd = SyncCommand(source, target, use_mtime, message, dryrun)
+        cmd = SyncCommand(source, target, use_mtime, message, dryrun, update_size)
         print(f"Checking sync")
         cmd.validate()
         print(f"Starting sync")

--- a/python/pyxet/pyxet/file_system.py
+++ b/python/pyxet/pyxet/file_system.py
@@ -334,6 +334,16 @@ class XetFS(fsspec.spec.AbstractFileSystem):
         else:
             return [{'name': r['name'], 'type': 'branch'} for r in res]
 
+    def update_size(self, path, bucket_size):
+        """
+        Calls Xetea to update the size of a synchronized S3 bucket for the repo.
+        """
+        url_path = parse_url(path, self.domain)
+        if url_path.remote == '':
+            raise ValueError("Incomplete path: Expecting xet://user/repo")
+        body = json.dumps({"size": bucket_size})
+        _manager.api_query(url_path.remote, "bucket_size", "post", body)
+
     def ls(self, path, detail=True, **kwargs):
         """List objects at path.
         This should include subdirectories and files at that location. The

--- a/python/pyxet/pyxet/file_system.py
+++ b/python/pyxet/pyxet/file_system.py
@@ -340,9 +340,14 @@ class XetFS(fsspec.spec.AbstractFileSystem):
         """
         url_path = parse_url(path, self.domain)
         if url_path.remote == '':
-            raise ValueError("Incomplete path: Expecting xet://user/repo")
-        body = json.dumps({"size": bucket_size})
-        _manager.api_query(url_path.remote, "bucket_size", "post", body)
+            raise ValueError("Incomplete path: Expecting xet://user/repo/branch")
+        if url_path.branch == '':
+            raise ValueError("No branch in path")
+        body = json.dumps({
+            'size': bucket_size,
+            'branch': url_path.branch
+        })
+        _manager.api_query(url_path.remote, "remote_size", "post", body)
 
     def ls(self, path, detail=True, **kwargs):
         """List objects at path.

--- a/python/pyxet/tests/requirements.txt
+++ b/python/pyxet/tests/requirements.txt
@@ -1,5 +1,5 @@
 cloudpickle
-fsspec
+fsspec==2023.9.2
 joblib
 pandas
 pyarrow

--- a/python/pyxet/tests/sync_test.py
+++ b/python/pyxet/tests/sync_test.py
@@ -32,7 +32,7 @@ def test_get_normalized_fs_protocol_and_path(monkeypatch):
 
 
 def check_sync_validate(src, dst, is_valid):
-    cmd = SyncCommand(src, dst, False, '', False)
+    cmd = SyncCommand(src, dst, False, '', False, False)
     try:
         cmd.validate()
         assert is_valid
@@ -85,7 +85,7 @@ def test_sync_command_s3():
     fs.make_branch(CONSTANTS.TESTING_SYNCREPO, 'main', branch)
     src_path = f'{CONSTANTS.TESTING_SYNCREPO}/{branch}'
 
-    cmd = SyncCommand(f's3://{CONSTANTS.S3_BUCKET}/sync1', f'xet://{src_path}', False, 'test sync from s3', False)
+    cmd = SyncCommand(f's3://{CONSTANTS.S3_BUCKET}/sync1', f'xet://{src_path}', False, 'test sync from s3', False, False)
     cmd.validate()
     stats = cmd.run()
     assert stats.ignored == 0


### PR DESCRIPTION
Fixes: https://github.com/xetdata/xethub/issues/4521

- Adds a flag to `xet sync` (`--update-size`) to update the bucket size of the repo following completion of the sync call.
- Adds a method: `update_size` to XetFS to call Xetea's `/api/xet/repos/<user>/<repo>/bucket_size` url to update the bucket size.