### PR TITLE
Prepend xet:// protocol to ls()

### DIFF
--- a/python/pyxet/pyxet/cli.py
+++ b/python/pyxet/pyxet/cli.py
@@ -166,9 +166,6 @@ class PyxetCLI:
             if raw:
                 print(listing)
             else:
-                if fs.protocol == 'xet':
-                    for entry in listing:
-                        entry['name'] = 'xet://' + entry['name']
                 print(tabulate(listing, headers="keys"))
             return listing
         except Exception as e:

--- a/python/pyxet/pyxet/file_system.py
+++ b/python/pyxet/pyxet/file_system.py
@@ -417,7 +417,7 @@ class XetFS(fsspec.spec.AbstractFileSystem):
                                             url_path.path)
 
         if detail:
-            return [{"name": prefix + '/' + fname,
+            return [{"name": 'xet://' + prefix + '/' + fname,
                      "size": finfo.size,
                      "type": finfo.ftype}
                     for fname, finfo in zip(files, file_info)]


### PR DESCRIPTION
Fix https://github.com/xetdata/xethub/issues/4553.
Instead of prepend the 'xet://' in the cli.py::ls, do it in file_system.py::ls because pyarrow checks if the children path prefix in a directory matches that directory path.