### PR TITLE
disable importing rpyxet when doc builds

### DIFF
--- a/python/pyxet/pyxet/file_operations.py
+++ b/python/pyxet/pyxet/file_operations.py
@@ -5,7 +5,9 @@ import threading
 from concurrent.futures import ThreadPoolExecutor
 from fnmatch import fnmatch
 from collections import namedtuple
-from .rpyxet import rpyxet
+
+if 'SPHINX_BUILD' not in os.environ:
+    from .rpyxet import rpyxet
 
 import fsspec
 


### PR DESCRIPTION
Similarly done at https://github.com/xetdata/pyxet/blob/fd7a21db96913d7c34284040ed28c8b1fd123134/python/pyxet/pyxet/file_system.py#L13 and https://github.com/xetdata/pyxet/blob/fd7a21db96913d7c34284040ed28c8b1fd123134/python/pyxet/pyxet/cli.py#L19