### PR TITLE
filter out invalid s3 files

### DIFF
--- a/python/pyxet/pyxet/sync.py
+++ b/python/pyxet/pyxet/sync.py
@@ -3,7 +3,7 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from functools import partial
 
-from pyxet.util import _get_fs_and_path, _isdir, _rel_path, _path_join, _path_dirname
+from pyxet.util import _get_fs_and_path, _isdir, _rel_path, _path_join, _path_dirname, _is_illegal_subdirectory_file_name
 from pyxet.file_operations import _single_file_copy_impl, CopyUnit
 
 XET_MTIME_FORMAT = '%Y-%m-%dT%H:%M:%S%z'
@@ -101,7 +101,7 @@ class SyncCommand:
         for abs_path, src_info in self._src_fs.find(src_path, detail=True).items():
             relpath = _rel_path(abs_path, src_path)
 
-            if relpath == '.':
+            if _is_illegal_subdirectory_file_name(relpath):
                 print(f"{abs_path} is an invalid file (not copied).")
                 continue
 
@@ -124,7 +124,7 @@ class SyncCommand:
         for abs_path, src_info in self._src_fs.find(src_path, detail=True).items():
             relpath = _rel_path(abs_path, src_path)
 
-            if relpath == '.':
+            if _is_illegal_subdirectory_file_name(relpath):
                 print(f"{abs_path} is an invalid file (not copied).")
                 continue
 

--- a/python/pyxet/pyxet/sync.py
+++ b/python/pyxet/pyxet/sync.py
@@ -100,6 +100,11 @@ class SyncCommand:
         total_size = 0
         for abs_path, src_info in self._src_fs.find(src_path, detail=True).items():
             relpath = _rel_path(abs_path, src_path)
+
+            if relpath == '.':
+                print(f"{abs_path} is an invalid file (not copied).")
+                continue
+
             dest_for_this_path = _path_join(self._dest_fs, dest_path, relpath)
             dest_info = dest_files.get(dest_for_this_path)
 
@@ -118,6 +123,11 @@ class SyncCommand:
         total_size = 0
         for abs_path, src_info in self._src_fs.find(src_path, detail=True).items():
             relpath = _rel_path(abs_path, src_path)
+
+            if relpath == '.':
+                print(f"{abs_path} is an invalid file (not copied).")
+                continue
+
             dest_for_this_path = _path_join(self._dest_fs, dest_path, relpath)
             if src_info['type'] != 'directory':
                 partial_func = partial(self._sync_with_mtime_task, abs_path, dest_for_this_path, src_info)

--- a/python/pyxet/pyxet/util.py
+++ b/python/pyxet/pyxet/util.py
@@ -119,3 +119,5 @@ def _path_normalize(fs, path, strip_trailing_slash = True, keep_relative = False
     else:
         return path
 
+def _is_illegal_subdirectory_file_name(path):
+    return path == '.' or path == '' or path == '..'


### PR DESCRIPTION
Some s3 bucket contains entries with names that exactly matches a directory name but is a file. E.g.
```
(.env) di@di-mbp ~ % xet ls s3://1000genomes/alignment_indices/
Key                                                                               LastModified               ETag                                    Size  StorageClass    type        size 
--------------------------------------------------------------------------------  -------------------------  ----------------------------------  --------  --------------  ------  -------- 
1000genomes/alignment_indices/                                                    2013-08-06 16:11:51+00:00  "d41d8cd98f00b204e9800998ecf8427e"         0  STANDARD        file           0
```

This results in bad destination names `.`. See more in https://github.com/xetdata/xethub/issues/5055

This detects, ignores and warns the user of such files.

Test:
```
(.env) di@di-mbp ~ % XET_ENDPOINT=hub.xetsvc.com xet sync s3://1000genomes/alignment_indices/ xet://seanses-dev/sync-test/main
Checking sync
Starting sync
1000genomes/alignment_indices/ is an invalid file (not copied).
Copying 1000genomes/alignment_indices/20091216.alignment.index to seanses-dev/sync-test/main/20091216.alignment.index
...
```

Related issue: https://github.com/xetdata/xethub/issues/5055