### PR TITLE
Fix docs build dep version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 myst-parser
 Sphinx
 sphinx-rtd-theme
-sphinx-book-theme==0.3.3
+sphinx-book-theme
 boto3
 fsspec
 typer


### PR DESCRIPTION
Readthedocs build failed (https://readthedocs.org/projects/pyxet/builds/23210757/) because `sphinx-book-theme==0.3.3` requires `sphinx>=3,<5`: 
```
Running Sphinx v4.5.0
Generating for pyxet 0.1.7-rc1
loading translations [en]... done

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyxet/envs/latest/lib/python3.11/site-packages/sphinx/registry.py", line 438, in load_extension
    metadata = setup(app)
               ^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyxet/envs/latest/lib/python3.11/site-packages/sphinxcontrib/applehelp/__init__.py", line 230, in setup
    app.require_sphinx('5.0')
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyxet/envs/latest/lib/python3.11/site-packages/sphinx/application.py", line 393, in require_sphinx
    raise VersionRequirementError(version)
sphinx.errors.VersionRequirementError: 5.0

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyxet/envs/latest/lib/python3.11/site-packages/sphinx/cmd/build.py", line 272, in build_main
    app = Sphinx(args.sourcedir, args.confdir, args.outputdir,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyxet/envs/latest/lib/python3.11/site-packages/sphinx/application.py", line 219, in __init__
    self.setup_extension(extension)
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyxet/envs/latest/lib/python3.11/site-packages/sphinx/application.py", line 380, in setup_extension
    self.registry.load_extension(self, extname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyxet/envs/latest/lib/python3.11/site-packages/sphinx/registry.py", line 441, in load_extension
    raise VersionRequirementError(
sphinx.errors.VersionRequirementError: The sphinxcontrib.applehelp extension used by this project needs at least Sphinx v5.0; it therefore cannot be built with this version.

Sphinx version error:
The sphinxcontrib.applehelp extension used by this project needs at least Sphinx v5.0; it therefore cannot be built with this version.
```