### PR TITLE
Support sync of a single file and print dryrun operations

### DIFF
--- a/python/pyxet/pyxet/cli.py
+++ b/python/pyxet/pyxet/cli.py
@@ -150,6 +150,8 @@ class PyxetCLI:
         print(f"Checking sync")
         cmd.validate()
         print(f"Starting sync")
+        if dryrun:
+            print("This is a dryrun")
         stats = cmd.run()
         if not dryrun:
             print(f"Completed sync. Copied: {stats.copied} files, ignored: {stats.ignored} files")

--- a/python/pyxet/pyxet/sync.py
+++ b/python/pyxet/pyxet/sync.py
@@ -92,15 +92,12 @@ class SyncCommand:
         Note that ls on xet-fs doesn't return an mtime and thus, will not be able to compare
         on that field.
         """
-
+        # This only syncs folders. single files should always go to sync_with_info
         try:
             dest_files = self._dest_fs.find(dest_path, detail=True)
         except RuntimeError:
             dest_files = {}
-
         total_size = 0
-
-        # syncing a folder
         for abs_path, src_info in self._src_fs.find(src_path, detail=True).items():
             relpath = _rel_path(abs_path, src_path)
 

--- a/python/pyxet/tests/sync_test.py
+++ b/python/pyxet/tests/sync_test.py
@@ -44,8 +44,6 @@ def test_sync_command_validate_local():
     pyxet.login(CONSTANTS.TESTING_USERNAME, CONSTANTS.TESTING_TOKEN, email="a@a.com")
 
     check_sync_validate('.', f'xet://{CONSTANTS.TESTING_SYNCREPO}/main', True)
-    check_sync_validate('/nonexistent', f'xet://{CONSTANTS.TESTING_SYNCREPO}/main', False)
-    check_sync_validate('./sync_test.py', f'xet://{CONSTANTS.TESTING_SYNCREPO}/main', False)
     check_sync_validate('xet://XetHub/grapp2/main', f'xet://{CONSTANTS.TESTING_SYNCREPO}/sync-branch/sync', False)
     check_sync_validate('.', f'xet://{CONSTANTS.TESTING_SYNCREPO}/nonexistent-branch', False)
     check_sync_validate('.', './other', False)


### PR DESCRIPTION
Support syncing of a single file. For instance:
```
xet sync s3://bucket/a.csv xet://ylow/repo/main
```

Also, --dryrun should print all the copy operations it would have performed. This helps a lot in testing and debugging.