### PR TITLE
Update URL logic parsing to not force xethub.com as host

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -38,6 +38,7 @@ jobs:
           export PATH="/usr/local/opt/make/libexec/gnubin:$PATH"
           export CXXFLAGS="-stdlib=libc++"
           cd python/pyxet
+          rustup target add x86_64-apple-darwin
           rustup target add aarch64-apple-darwin
           maturin build --target universal2-apple-darwin -r 
       - name: Unit and integration tests (non-Windows)

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -51,7 +51,7 @@ jobs:
           cd python/pyxet
           pip install -r tests/requirements.txt
           pip install target/wheels/pyxet*.whl
-          pytest tests
+          pytest pyxet/ tests/ # Tests also live in the code itself
       - name: Unit and integration tests (Windows)
         if: runner.os == 'Windows'
         env:
@@ -66,5 +66,5 @@ jobs:
             pip install $_.FullName
           }
           cd ..
-          python -m pytest pyxet/tests
+          python -m pytest pyxet/tests/ pyxet/pyxet/  # Tests also live in the code itself, so run those too
 

--- a/python/pyxet/pyxet/file_system.py
+++ b/python/pyxet/pyxet/file_system.py
@@ -70,6 +70,7 @@ class XetFS(fsspec.spec.AbstractFileSystem):
         if 'XET_ENDPOINT' in os.environ:
             domain = os.environ['XET_ENDPOINT']
         if domain is None:
+            # Read it from the config
             domain = 'xethub.com'
         self.domain = domain
         self.intrans = False

--- a/python/pyxet/pyxet/url_parsing.py
+++ b/python/pyxet/pyxet/url_parsing.py
@@ -4,11 +4,13 @@ Provides URL parsing for Xet Repos
 import unittest
 from collections import namedtuple
 from urllib.parse import urlparse
+import sys
 
 XetPathInfo = namedtuple('XetPathInfo', ('remote', 'branch', 'path'))
 
+has_warned_user_on_url_format = False
 
-def parse_url(url, force_domain='xethub.com', partial_remote=False):
+def parse_url(url, default_domain='xethub.com', partial_remote=False, recursive_skip_checks = False):
     """
     Parses a Xet URL of the form 
      - xet://user/repo/branch/[path]
@@ -22,17 +24,18 @@ def parse_url(url, force_domain='xethub.com', partial_remote=False):
     If partial_remote==True, allows [repo] to be optional. i.e. it will
     parse /user or xet://user
     """
+
     url = url.lstrip('/')
     parse = urlparse(url)
     if parse.scheme == '':
         parse = parse._replace(scheme='xet')
 
-    # support force_domain with a scheme (http/https)
-    domain_split = force_domain.split('://')
+    # support default_domain with a scheme (http/https)
+    domain_split = default_domain.split('://')
     scheme = 'https'
     if len(domain_split) == 2:
         scheme = domain_split[0]
-        force_domain = domain_split[1]
+        default_domain = domain_split[1]
 
     if parse.scheme != 'xet':
         raise ValueError('Invalid protocol')
@@ -40,144 +43,210 @@ def parse_url(url, force_domain='xethub.com', partial_remote=False):
     # Handle the case where we are xet://user/repo. In which case the domain
     # parsed is not xethub.com and domain="user".
     # we rewrite the parse the handle this case early.
-    if parse.netloc != force_domain:
-        if parse.netloc == 'xethub.com':
-            parse = parse._replace(netloc=force_domain)
-        else:
-            # this is of the for xet://user/repo/...
-            # join user back with path
-            newpath = f"/{parse.netloc}{parse.path}"
-            # replace the netloc
-            true_netloc = force_domain
-            parse = parse._replace(netloc=true_netloc, path=newpath)
+    if "@" not in parse.netloc:
+        if not recursive_skip_checks:
+            global has_warned_user_on_url_format
+            
+            if not has_warned_user_on_url_format:
+                sys.stderr.write("Warning:  The use of the xet:// prefix without an endpoint is deprecated and will be disabled in the future.\n"
+                                f"          Please switch URLs to use the format xet://<user>@<endpoint>/<repo>/<branch>/<path>.\n"
+                                f"          Endpoint now defaulting to {default_domain}.\n\n")
+                has_warned_user_on_url_format = True
+
+    else:
+        # Hack until we can clean up this parsing logic
+        user_at_domain = parse.netloc.split("@")
+        if len(user_at_domain) == 2:
+            user, domain = user_at_domain
+            # In this case, swap out the url to the old form and tell it to reparse it.  
+            # This is easier than trying to figure out how to rework the url parsing tool logic
+            new_url = url.replace(parse.netloc, f"{domain}/{user}")
+            return parse_url(new_url, default_domain=domain, partial_remote=partial_remote, recursive_skip_checks=True)
+        else: 
+            raise ValueError(f"Cannot parse user and endpoint from {parse.netloc}")
+
+    if not parse.netloc.endswith(".com"):  # Cheap way now to see if it's a website or not; we won't hit this with the old format.
+        # this is of the for xet://user/repo/...
+        # join user back with path
+        newpath = f"/{parse.netloc}/{parse.path}".replace("//", "/")  
+        # replace the netloc
+        true_netloc = default_domain
+        parse = parse._replace(netloc=true_netloc, path=newpath)
 
     # Split the known path and try to split out the user/repo/branch/path components
     path = parse.path
-    components = path.split('/')
-    # path always begin with a '/', so 1st component is always empty
-    # so the minimum for a remote is xethub.com/user/repo
-    if len(components) < 3:
-        # <=2 components. Note that 1st component is always empty 
-        if partial_remote and len(components) == 2:
+
+    path_endswith_slash = path.endswith("/")
+
+    components = list([t for t in [t.strip() for t in path.split('/')] if t])
+
+    print(f"Components={components}")
+
+    # so the minimum for a remote is xethub.com/user/
+    if len(components) < 2:
+        if partial_remote and len(components) >= 1:
             replacement_parse_path = '/'.join(components)
             parse = parse._replace(path=replacement_parse_path, scheme=scheme)
             return XetPathInfo(parse.geturl(), "", "")
-        raise ValueError("Invalid Xet URL format: Expecting xet://user/repo/[branch]/[path]")
+        raise ValueError(f"Invalid Xet URL format: Expecting xet://user/repo/[branch]/[path], components={components}, path={path}")
 
     branch = ""
-    if len(components) >= 4:
-        branch = components[3]
+    if len(components) >= 3:
+        branch = components[2]  
 
     path = ""
-    if len(components) >= 5:
-        path = '/'.join(components[4:])
+    if len(components) >= 4:
+        path = '/'.join(components[3:])
 
-    # we leave url with the first 3 components. i.e. "/user/repo"
-    replacement_parse_path = '/'.join(components[:3])
+    if path and path_endswith_slash: 
+        path = path + '/'
+
+    # we leave url with the first 2 components. i.e. "/user/repo"
+    replacement_parse_path = '/'.join(components[:2])
     parse = parse._replace(path=replacement_parse_path, scheme=scheme)
 
-    return XetPathInfo(parse.geturl(), branch, path)
+    return XetPathInfo(parse.geturl().rstrip("/"), branch, path)
 
 
 class ParseUrlTest(unittest.TestCase):
+
+    def parse_url(self, url, expect_warning, **kwargs):
+        global has_warned_user_on_url_format
+        has_warned_user_on_url_format = False
+        parse = parse_url(url, **kwargs)
+        self.assertEqual(has_warned_user_on_url_format, expect_warning)
+        print(f"Test parse result = {parse}")
+        return parse
+
     def test_parse_xet_url(self):
-        parse = parse_url("xet://xethub.com/user/repo/branch/hello/world")
+        parse = self.parse_url("xet://xethub.com/user/repo/branch/hello/world", True)
         self.assertEqual(parse.remote, "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "hello/world")
 
-        parse = parse_url("xet://xethub.com/user/repo/branch/hello/world/")
+        parse = self.parse_url("xet://xethub.com/user/repo/branch/hello/world/", True)
         self.assertEqual(parse.remote, "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "hello/world/")
 
-        parse = parse_url("xet://xethub.com/user/repo/branch/")
+        parse = self.parse_url("xet://xethub.com/user/repo/branch/", True)
         self.assertEqual(parse.remote, "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "")
 
-        parse = parse_url("xet://xethub.com/user/repo/branch")
+        parse = self.parse_url("xet://xethub.com/user/repo/branch", True)
         self.assertEqual(parse.remote, "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "")
 
-        parse = parse_url("xet://xethub.com/user/repo")
+        parse = self.parse_url("xet://xethub.com/user/repo", True)
         self.assertEqual(parse.remote, "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "")
         self.assertEqual(parse.path, "")
 
-        parse = parse_url("xet://xethub.com/user/repo/branch", force_domain='xetbeta.com')
-        self.assertEqual(parse.remote, "https://xetbeta.com/user/repo")
+        parse = self.parse_url("xet://xethub.com/user/repo/branch", True, default_domain='xetbeta.com')
+        self.assertEqual(parse.remote, "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "")
 
         with self.assertRaises(ValueError):
-            self.parse = parse_url("xet://xethub.com/user")
+            self.parse = self.parse_url("xet://xethub.com/user", True)
 
     def test_parse_xet_url_truncated(self):
-        parse = parse_url("xet://user/repo/branch/hello/world")
+        parse = self.parse_url("xet://user/repo/branch/hello/world", True)
         self.assertEqual(parse.remote, "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "hello/world")
 
-        parse = parse_url("xet://user/repo/branch/hello/world/")
+        parse = self.parse_url("xet://user/repo/branch/hello/world/", True)
         self.assertEqual(parse.remote, "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "hello/world/")
 
-        parse = parse_url("xet://user/repo/branch/")
+        parse = self.parse_url("xet://user/repo/branch/", True)
         self.assertEqual(parse.remote, "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "")
 
-        parse = parse_url("xet://user/repo/branch")
+        parse = self.parse_url("xet://user/repo/branch", True)
         self.assertEqual(parse.remote, "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "")
 
-        parse = parse_url("xet://user/repo")
+        parse = self.parse_url("xet://user/repo", True)
         self.assertEqual(parse.remote, "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "")
         self.assertEqual(parse.path, "")
 
-        parse = parse_url("xet://user/repo/branch", force_domain='xetbeta.com')
+        parse = self.parse_url("xet://user/repo/branch", True, default_domain='xetbeta.com')
         self.assertEqual(parse.remote, "https://xetbeta.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "")
 
         with self.assertRaises(ValueError):
-            self.parse = parse_url("xet://user")
+            self.parse = self.parse_url("xet://user", True)
 
     def test_parse_plain_path(self):
-        parse = parse_url("/user/repo/branch/hello/world")
+        parse = self.parse_url("/user/repo/branch/hello/world", True)
         self.assertEqual(parse.remote, "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "hello/world")
 
-        parse = parse_url("/user/repo/branch/hello/world/")
+        parse = self.parse_url("/user/repo/branch/hello/world/", True)
         self.assertEqual(parse.remote, "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "hello/world/")
 
-        parse = parse_url("/user/repo/branch/")
+        parse = self.parse_url("/user/repo/branch/", True)
         self.assertEqual(parse.remote, "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "")
 
-        parse = parse_url("/user/repo/branch")
+        parse = self.parse_url("/user/repo/branch", True)
         self.assertEqual(parse.remote, "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "")
 
-        parse = parse_url("/user/repo")
+        parse = self.parse_url("/user/repo", True)
         self.assertEqual(parse.remote, "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "")
         self.assertEqual(parse.path, "")
 
-        parse = parse_url("/user/repo/branch", force_domain='xetbeta.com')
+        parse = self.parse_url("/user/repo/branch", True, default_domain='xetbeta.com')
         self.assertEqual(parse.remote, "https://xetbeta.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "")
 
         with self.assertRaises(ValueError):
-            self.parse = parse_url("xet://xethub.com/user")
+            self.parse = self.parse_url("xet://xethub.com/user", True)
+    
+    def test_parse_xet_url_correct(self):
+        parse = self.parse_url("xet://user@xh.com/repo/branch/hello/world", False)
+        self.assertEqual(parse.remote, "https://xh.com/user/repo")
+        self.assertEqual(parse.branch, "branch")
+        self.assertEqual(parse.path, "hello/world")
+
+        parse = self.parse_url("xet://user@xh.com/repo/branch/hello/world/", False)
+        self.assertEqual(parse.remote, "https://xh.com/user/repo")
+        self.assertEqual(parse.branch, "branch")
+        self.assertEqual(parse.path, "hello/world/")
+
+        parse = self.parse_url("xet://user@xh.com/repo/branch/", False)
+        self.assertEqual(parse.remote, "https://xh.com/user/repo")
+        self.assertEqual(parse.branch, "branch")
+        self.assertEqual(parse.path, "")
+
+        parse = self.parse_url("xet://user@xh.com/repo/branch", False)
+        self.assertEqual(parse.remote, "https://xh.com/user/repo")
+        self.assertEqual(parse.branch, "branch")
+        self.assertEqual(parse.path, "")
+
+        parse = self.parse_url("xet://user@xh.com/repo", False)
+        self.assertEqual(parse.remote, "https://xh.com/user/repo")
+        self.assertEqual(parse.branch, "")
+        self.assertEqual(parse.path, "")
+
+        parse = self.parse_url("xet://user@xh.com/repo/branch", False, default_domain='xetbeta.com')
+        self.assertEqual(parse.remote, "https://xh.com/user/repo")
+        self.assertEqual(parse.branch, "branch")
+        self.assertEqual(parse.path, "")

--- a/python/pyxet/tests/cli_cp_test.py
+++ b/python/pyxet/tests/cli_cp_test.py
@@ -8,6 +8,14 @@ import tempfile
 from pyxet.file_operations import perform_copy, build_cp_action_list
 
 
+def delete_branch(repo, branch, *args): 
+    try:
+        pyxet.BranchCLI.delete(repo, branch, *args)
+    except Exception as e:
+        print(f"WARNING: Exception trying to delete branch {branch} on {repo}: {e}")
+        
+
+
 def test_single_file_upload():
     user = utils.test_account_login()
     repo = utils.test_repo()
@@ -47,7 +55,7 @@ def test_single_file_upload():
         finally:
             shutil.rmtree(dir)
     finally:
-        pyxet.BranchCLI.delete(f"xet://{user}/{repo}", b1, True)
+        delete_branch(f"xet://{user}/{repo}", b1, True)
 
 def test_multiple_files_upload():
     user = utils.test_account_login()
@@ -88,7 +96,7 @@ def test_multiple_files_upload():
         finally:
             shutil.rmtree(dir)
     finally:
-        pyxet.BranchCLI.delete(f"xet://{user}/{repo}", b1, True)
+        delete_branch(f"xet://{user}/{repo}", b1, True)
 
 def test_glob_nonrecursive_upload():
     user = utils.test_account_login()
@@ -134,7 +142,7 @@ def test_glob_nonrecursive_upload():
         finally:
             shutil.rmtree(dir)
     finally:
-        pyxet.BranchCLI.delete(f"xet://{user}/{repo}", b1, True)
+        delete_branch(f"xet://{user}/{repo}", b1, True)
 
 def test_glob_recursive_upload():
     user = utils.test_account_login()
@@ -181,7 +189,7 @@ def test_glob_recursive_upload():
         finally:
             shutil.rmtree(dir)
     finally:
-        pyxet.BranchCLI.delete(f"xet://{user}/{repo}", b1, True)
+        delete_branch(f"xet://{user}/{repo}", b1, True)
     
 def test_directory_nonrecursive_upload():
     user = utils.test_account_login()
@@ -231,7 +239,7 @@ def test_directory_nonrecursive_upload():
         finally:
             shutil.rmtree(dir)
     finally:
-        pyxet.BranchCLI.delete(f"xet://{user}/{repo}", b1, True)
+        delete_branch(f"xet://{user}/{repo}", b1, True)
 
 def test_directory_recursive_upload():
     user = utils.test_account_login()
@@ -279,7 +287,7 @@ def test_directory_recursive_upload():
             shutil.rmtree(dir)
         
     finally:
-        pyxet.BranchCLI.delete(f"xet://{user}/{repo}", b1, True)
+        delete_branch(f"xet://{user}/{repo}", b1, True)
 
 # According to https://filesystem-spec.readthedocs.io/en/latest/copying.html#single-source-to-single-target
 # section 1e, if the trailing slash is omitted from "source/subdir" then the subdir is also copied, 
@@ -334,7 +342,7 @@ def _test_directory_recursive_noslash_upload():
             shutil.rmtree(dir)
         
     finally:
-        pyxet.BranchCLI.delete(f"xet://{user}/{repo}", b1, True)
+        delete_branch(f"xet://{user}/{repo}", b1, True)
 
 def test_large_batch_upload():
     user = utils.test_account_login()
@@ -356,7 +364,7 @@ def test_large_batch_upload():
             shutil.rmtree(dir)
 
     finally:
-        pyxet.BranchCLI.delete(f"xet://{user}/{repo}", b1, True)
+        delete_branch(f"xet://{user}/{repo}", b1, True)
 
 def test_size_hint():
     user = utils.test_account_login()


### PR DESCRIPTION
- Fixes bugs in parsing (parsing tests were never actually run)
- Tests now pass.
- Explicit domains are not forced to be xethub.com. 
- Deprecation warnings given now. 