### PR TITLE
Update readthedocs to reference endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,15 +103,17 @@ Our examples are based on a small Titanic dataset you can see and explore [here]
 
 A XetHub URL for pyxet is in the form:
 ```
-xet://<repo_owner>/<repo_name>/<branch>/<path_to_file>
+xet://<endpoint>:<repo_owner>/<repo_name>/<branch>/<path_to_file>
 ```
+
+Use our public `xethub.com` endpoint unless you're on a custom enterprise deployment.
 
 Reading files from pyxet is easy: `pyxet.open` on a Xet path will return a
 python file-like object which you can directly read from.
 
 ```python
 import pyxet            
-print(pyxet.open('xet://XetHub/titanic/main/README.md').readlines())
+print(pyxet.open('xet://xethub.com:XetHub/titanic/main/README.md').readlines())
 ```
 
 
@@ -125,7 +127,7 @@ dataframe:
 import pyxet            # make xet:// protocol available
 import pandas as pd     # assumes pip install pandas has been run
 
-df = pd.read_csv('xet://XetHub/titanic/main/titanic.csv')
+df = pd.read_csv('xet://xethub.com:XetHub/titanic/main/titanic.csv')
 df
 ```
 
@@ -198,11 +200,11 @@ To write files with pyxet, you need to first make a repository you have access t
 An easy thing you can do is to simply fork the titanic repo. You can do so with
 
 ```bash
-xet repo fork xet://XetHub/titanic
+xet repo fork xet://xethub.com:XetHub/titanic
 ```
 (see the Xet CLI documentation below)
 
-This will create a private version of the titanic repository under `xet://<username>/titanic`.
+This will create a private version of the titanic repository under `xet://xethub.com:<username>/titanic`.
 
 Unlike typical blob stores, XetHub writes are *transactional*. This means the
 entire write succeeds, or the entire write fails 
@@ -229,27 +231,27 @@ The Xet Command line is the easiest way to interact with a Xet repository.
 ## Listing and time travel
 You can browse the repository with:
 ```bash
-xet ls xet://<username>/titanic/main
+xet ls xet://xethub.com:<username>/titanic/main
 ```
 
 You can even browse it at any point in history (say 5 minutes ago) with:
 ```bash
-xet ls xet://<username>/titanic/main@{5.minutes.ago}
+xet ls xet://xethub.com:<username>/titanic/main@{5.minutes.ago}
 ```
 
 ## Downloading
 This syntax works everywhere, you can download files with `xet cp`
 ```bash
 # syntax is similar to AWS CLI 
-xet cp xet://<username>/titanic/main/<path> <local_path>
-xet cp xet://<username>/titanic/main@{5.minutes.ago}/<path> <local_path>
+xet cp xet://xethub.com:<username>/titanic/main/<path> <local_path>
+xet cp xet://xethub.com:<username>/titanic/main@{5.minutes.ago}/<path> <local_path>
 ```
 
 And you can also use `xet cp` to upload files:
 
 ## Uploading
 ```bash
-xet cp <file/directory> xet://<username>/titanic/main/<path>
+xet cp <file/directory> xet://xethub.com:<username>/titanic/main/<path>
 ```
 Of course, you cannot rewrite history, so uploading to `main@{5.minutes.ago}`
 is prohibited. 
@@ -257,7 +259,7 @@ is prohibited.
 ## Branches
 You can easily create branches for collaboration:
 ```bash
-xet branch make xet://<username>/titanic main another_branch
+xet branch make xet://xethub.com:<username>/titanic main another_branch
 ```
 This is fast regardless of the size of the repo.
 
@@ -267,9 +269,9 @@ copy of a file which you accidentally overwrote:
 
 ```bash
 # copying across branch
-xet cp xet://<username>/titanic/branch/<file> xet://<username>/titanic/main/<file>
+xet cp xet://xethub.com:<username>/titanic/branch/<file> xet://xethub.com:<username>/titanic/main/<file>
 # copying from history to current
-xet cp xet://<username>/titanic/main@{5.minutes.ago}/<file> xet://<username>/titanic/main/<file>
+xet cp xet://xethub.com:<username>/titanic/main@{5.minutes.ago}/<file> xet://xethub.com:<username>/titanic/main/<file>
 ```
 
 ## S3, GCP, etc

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -97,7 +97,7 @@ Read a CSV file:
     import pyxet            # make xet:// protocol available
     import pandas as pd     # assumes pip install pandas has been run
 
-    df = pd.read_csv('xet://XetHub/titanic/main/titanic.csv')
+    df = pd.read_csv('xet://xethub.com:XetHub/titanic/main/titanic.csv')
 
 Checkout the rest of the documentation for detailed usage examples!
 

--- a/docs/markdowns/cli.md
+++ b/docs/markdowns/cli.md
@@ -43,23 +43,23 @@ list files and folders
 ```bash
 
 # list files and directories
-$ xet ls xet://user/repo/main/path/to/file/or/dir
+$ xet ls xet://xethub.com:user/repo/main/path/to/file/or/dir
 # list repos
-$ xet ls xet://user/
+$ xet ls xet://xethub.com:user/
 
 # list organisation users
 $ xet ls 
 # list all available repos for current user + organisation
 $ xet repo ls
 # list all available branches for a project
-$ xet branch ls xet://user/repo
+$ xet branch ls xet://xethub.com:user/repo
 
 # examples
-$ xet ls xet://xdssio/gitease/giteas
+$ xet ls xet://xethub.com:xdssio/gitease/gitease
 xdssio/gitease/gitease/__init__.py         2  file
 xdssio/gitease/gitease/cli.py           6146  file
 
-$ xet ls xet://xdssio
+$ xet ls xet://xethub.com:xdssio
 name                          type
 ----------------------------  ------
 xdssio/datasets               repo
@@ -98,10 +98,10 @@ $ xet ls s3://<bucket>
 
 ```bash
 # Copy files or directories
-$ xet cp xet://user/repo/branch/path/to/source xet://user/repo/branch/path/to/target
+$ xet cp xet://xethub.com:user/repo/branch/path/to/source xet://xethub.com:user/repo/branch/path/to/target
 
 # examples
-$ xet cp xet://xdssio/titanic/experiment-1/titanic.csv xet://xdssio/titanic/experiment-2/titanic.csv
+$ xet cp xet://xethub.com:xdssio/titanic/experiment-1/titanic.csv xet://xethub.com:xdssio/titanic/experiment-2/titanic.csv
 Copying xdssio/titanic/experiment-1/titanic.csv to xdssio/titanic/experiment-2/titanic.csv...
 ```
 
@@ -135,10 +135,10 @@ $ xet cp s3://... xet://...
 
 ```bash
 
-$ xet mv xet://user/repo/branch/path/to/source xet://user/repo/branch/path/to/target
+$ xet mv xet://xethub.com:user/repo/branch/path/to/source xet://xethub.com:user/repo/branch/path/to/target
 
 # examples 
-$ xet mv xet://xdssio/titanic/experiment-1/titanic.csv xet://xdssio/titanic/experiment-1/titanic2.csv
+$ xet mv xet://xethub.com:xdssio/titanic/experiment-1/titanic.csv xet://xethub.com:xdssio/titanic/experiment-1/titanic2.csv
 ```
 
 ## rm (delete)
@@ -159,10 +159,10 @@ $ xet mv xet://xdssio/titanic/experiment-1/titanic.csv xet://xdssio/titanic/expe
 ### Usage
 
 ```bash
-xet rm xet://user/repo/branch/path/to/file/or/dir
+xet rm xet://xethub.com:user/repo/branch/path/to/file/or/dir
 
 # examples
-$ xet rm xet://xdssio/titanic/experiment-2/titanic2.csv
+$ xet rm xet://xethub.com:xdssio/titanic/experiment-2/titanic2.csv
 Synchronizing with remote
 ```
 
@@ -185,10 +185,10 @@ Prints a file to stdout
 ### Usage
 
 ```bash
-xet cat xet://user/repo/branch/path/to/file
+xet cat xet://xethub.com:user/repo/branch/path/to/file
 
 # examples
-xet cat xet://xdssio/titanic/main/titanic.csv --limit=200
+xet cat xet://xethub.com:xdssio/titanic/main/titanic.csv --limit=200
 PassengerId,Survived,Pclass,Name,Sex,Age,SibSp,Parch,Ticket,Fare,Cabin,Embarked
 1,0,3,"Braund, Mr. Owen Harris",male,22,1,0,A/5 21171,7.25,,S
 2,1,1,"Cumings, Mrs. John Bradley (Florence Briggs Thaye%   
@@ -201,10 +201,10 @@ Provide information about a project branch or file.
 ### Usage
 
 ```bash
-$ xet info xet://user/repo/branch/path/to/file
+$ xet info xet://xethub.com:user/repo/branch/path/to/file
 
 # examples
-$ xet info xet://xdssio/titanic/main/titanic.csv
+$ xet info xet://xethub.com:xdssio/titanic/main/titanic.csv
 -------------------------------  -----  ----
 xdssio/titanic/main/titanic.csv  61194  file
 -------------------------------  -----  ----
@@ -220,7 +220,7 @@ This is great for data exploration and analysis.
 
 ```bash 
 ╭─ Arguments ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ *    source      TEXT  Repository and branch of the form xet://user/repo/branch [default: None] [required]                    │
+│ *    source      TEXT  Repository and branch of the form xet://xethub.com:user/repo/branch [default: None] [required]         │
 │ *    path        TEXT  Path to mount to. (or a drive letter on windows) [default: None] [required]                            │
 ╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ```
@@ -228,7 +228,7 @@ This is great for data exploration and analysis.
 ### Usage
 
 ```bash
-$ xet mount xet://user/repo/branch /path/to/local/dir
+$ xet mount xet://xethub.com:user/repo/branch /path/to/local/dir
 
 ## examples
 $ xet mount XetHub/Laion400M/main laion
@@ -258,13 +258,13 @@ The *branch* sub commands let you manage your project branches.
 # Create a new branch
 $ xet branch make repo source-branch new-branch
 # List branches
-$ xet branch ls xet://user/repo
+$ xet branch ls xet://xethub.com:user/repo
 # Delete a branch
-$ xet branch delete xet://user/repo/new-branch
+$ xet branch delete xet://xethub.com:user/repo/new-branch
 
 # examples
-$ xet branch make xet://xdssio/titanic main experiment-3
-$ xet branch list xet://xdssio/titanic
+$ xet branch make xet://xethub.com:xdssio/titanic main experiment-3
+$ xet branch list xet://xethub.com:xdssio/titanic
 name          type
 ------------  ------
 experiment-2  branch
@@ -272,7 +272,7 @@ experiment-1  branch
 experiment-3  branch
 main          branch
 
-$ xet branch delete xet://xdssio/titanic experiment-3 --yes
+$ xet branch delete xet://xethub.com:xdssio/titanic experiment-3 --yes
 ---------------------------------------------------
                     WARNING
 ---------------------------------------------------
@@ -281,7 +281,7 @@ Any data which only exists on a branch will become irreversibly inaccessible
 
 --yes is set. Issuing deletion
 
-$ xet branch info xet://xdssio/titanic main
+$ xet branch info xet://xethub.com:xdssio/titanic main
 ```
 
 ## repo
@@ -307,14 +307,14 @@ at https://xethub.com/<user>/<repo-name>/settings.
 # Create a new repository
 $ xet repo make repo-name
 # List repositories
-$ xet repo ls xet://user
+$ xet repo ls xet://xethub.com:user
 # fork a repository
-$ xet repo fork xet://user/repo-name xet://user/new-repo-name --private
+$ xet repo fork xet://xethub.com:user/repo-name xet://xethub.com:user/new-repo-name --private
 # Rename a repository
-$ xet repo rename xet://user/repo-name new-repo-name
+$ xet repo rename xet://xethub.com:user/repo-name new-repo-name
 
 examples
-xet repo fork xet://xdssio/titanic xet://xdssio/titanic-fork -p
+xet repo fork xet://xethub.com:xdssio/titanic xet://xethub.com:xdssio/titanic-fork -p
 ```
 
 ## sync
@@ -324,7 +324,7 @@ xet repo fork xet://xdssio/titanic xet://xdssio/titanic-fork -p
   is provided, then a file whose size is the same will be copied if the modification time for the source is 
   *later* than the target. Note that this flag makes the sync significantly slower.
 * Only non-xet sources (e.g. S3 or local filesystem) are allowed.
-* Only XetHub targets are allowed (i.e. `xet://<user>/<repo>/<branch>`).
+* Only XetHub targets are allowed (i.e. `xet://xethub.com:<user>/<repo>/<branch>`).
 * Modifying source files while a sync is happening has undefined behavior for whether those files copy. 
 
 ```bash
@@ -345,10 +345,10 @@ xet repo fork xet://xdssio/titanic xet://xdssio/titanic-fork -p
 
 ```bash
 # Sync remote S3 bucket to repo
-$ xet sync s3://bucket/path/to/source xet://user/repo/branch/path/to/target
+$ xet sync s3://bucket/path/to/source xet://xethub.com:user/repo/branch/path/to/target
 
 # Example sync from S3
-$ xet sync s3://my-files xet://XetHub/import-test/my-files
+$ xet sync s3://my-files xet://xethub.com:XetHub/import-test/my-files
 Checking sync
 Starting sync
 Copying my-files/data.csv to XetHub/import-test/my-files/data.csv...
@@ -357,7 +357,7 @@ Copying my-files/data2.csv to XetHub/import-test/my-files/data2.csv...
 Completed sync. Copied: 20 files, ignored: 277 files
 
 # Example sync from local
-$ xet sync . xet://XetHub/import-test/my-local-files
+$ xet sync . xet://xethub.com:XetHub/import-test/my-local-files
 Checking sync
 Starting sync
 Copying ./dir/data.csv to XetHub/import-test/my-local-files/data.csv...

--- a/docs/markdowns/filesystem.md
+++ b/docs/markdowns/filesystem.md
@@ -7,8 +7,10 @@ library. Use it to access local files, remote files, and files in XetHub.
 
 Xet URLs are in the form:
 ```sh
-xet://<repo_owner>/<repo_name>/<branch>/<path_to_file>
+xet://<endpoint>:<repo_owner>/<repo_name>/<branch>/<path_to_file>
 ```
+
+Use our public `xethub.com` endpoint unless you're on a custom enterprise deployment.
 
 The `<path_to_file>` argument is optional if the URL
 refers to a repository and the `xet://` prefix is optional when using pyxet.XetFS.
@@ -35,10 +37,10 @@ Example usage of `pyxet.XetFS`:
   fs = pyxet.XetFS()
 
   # List files in the repository.
-  files = fs.ls('xet://XetHub/Flickr30k/main')
+  files = fs.ls('xet://xethub.com:XetHub/Flickr30k/main')
 
   # Open a file from the repository.
-  f = fs.open('xet://XetHub/Flickr30k/main/results.csv')
+  f = fs.open('xet://xethub.com:XetHub/Flickr30k/main/results.csv')
 
   # Read the contents of the file.
   contents = f.read()
@@ -95,6 +97,6 @@ xet:// URLs must be used as file paths when interacting with these packages. For
   import pyxet   # make xet protocol available to fsspec
   import pandas as pd
 
-  df = pd.read_csv('xet://XetHub/Flickr30k/main/results.csv')
+  df = pd.read_csv('xet://xethub.com:XetHub/Flickr30k/main/results.csv')
 ```
 

--- a/docs/markdowns/filesystem.md
+++ b/docs/markdowns/filesystem.md
@@ -13,7 +13,7 @@ xet://<endpoint>:<repo_owner>/<repo_name>/<branch>/<path_to_file>
 Use our public `xethub.com` endpoint unless you're on a custom enterprise deployment.
 
 The `<path_to_file>` argument is optional if the URL
-refers to a repository and the `xet://` prefix is optional when using pyxet.XetFS.
+refers to a repository and the `xet://` prefix is optional when using pyxet.XetFS. If pyxet.FS is initialized with an endpoint, `xet://<endpoint>:` is inferred.
 
 ## Accessing private repositories
 
@@ -34,19 +34,19 @@ Example usage of `pyxet.XetFS`:
   import pyxet
 
   # Create a file system handle for a repository
-  fs = pyxet.XetFS()
+  fs = pyxet.XetFS('xethub.com')
 
   # List files in the repository.
-  files = fs.ls('xet://xethub.com:XetHub/Flickr30k/main')
+  files = fs.ls('XetHub/Flickr30k/main')
 
   # Open a file from the repository.
-  f = fs.open('xet://xethub.com:XetHub/Flickr30k/main/results.csv')
+  f = fs.open('XetHub/Flickr30k/main/results.csv')
 
   # Read the contents of the file.
   contents = f.read()
 
   # Write to a repository with an optional commit message
-with fs.transaction as tr:
+  with fs.transaction as tr:
     tr.set_commit_message("Writing things")
     fs.open("<user_name>/<repo_name>/main/foo", 'w').write("Hello world!")
 ```
@@ -55,10 +55,10 @@ with fs.transaction as tr:
 ```python
   import pyxet
 
-  fs = pyxet.XetFS()  # fsspec filesystem
+  fs = pyxet.XetFS('xethub.com')  # fsspec filesystem
 
   # Read functions
-  fs.info("xethub/titanic/main/titanic.csv")
+  fs.info("XetHub/titanic/main/titanic.csv")
   # returns repo level info: {'name': 'https://xethub.com/XetHub/titanic/titanic.csv', 'size': 61194, 'type': 'file'}
 
   fs.open("XetHub/titanic/main/titanic.csv", 'r').read(20)

--- a/docs/markdowns/model_versioning.md
+++ b/docs/markdowns/model_versioning.md
@@ -81,8 +81,8 @@ Optionally, use [Git submodules](https://git-scm.com/book/en/v2/Git-Tools-Submod
 
 
 ```bash
-xet://org/project (branch-prod/dev/ab-test-210322/ab-test-210323)
-├── data/ xet://org/project/data (submodule)
+xet://xethub.com:org/project (branch-prod/dev/ab-test-210322/ab-test-210323)
+├── data/ xet://xethub.com:org/project/data (submodule)
 │   ├── data.csv
 ├── models/
 │   ├── model.pkl

--- a/docs/markdowns/model_versioning_tutorial.md
+++ b/docs/markdowns/model_versioning_tutorial.md
@@ -69,7 +69,7 @@ fs = pyxet.XetFS()
 # a transaction is needed for write
 with fs.transaction as tr:
     tr.set_commit_message("Adding data")
-    fs.cp("data/titanic.csv", "xet://${XET_USER_NAME}/kickstart_data/main/titanic.csv")
+    fs.cp("data/titanic.csv", "xet://xethub.com:${XET_USER_NAME}/kickstart_data/main/titanic.csv")
 ```
 
 We can delete our local data file: `rm -rf data`.
@@ -94,7 +94,7 @@ Let’s adjust our Jupyter Notebook to load the data from “local” and not sa
 
 ```bash
 ...
-# df = pd.read_csv("xet://xdssio/titanic/main/titanic.csv") <-- delete
+# df = pd.read_csv("xet://xethub.com:xdssio/titanic/main/titanic.csv") <-- delete
 df = pd.read_csv("../data/titanic.csv")
 ...
 # df.to_csv('../data/data.csv', index=False) <-- delete
@@ -254,7 +254,7 @@ import pandas as pd
 username = os.getenv('XET_USER_NAME')
 results = []
 for branch in ["prod", "experiment1"]:
-    results.append(pd.read_csv(pyxet.open(f"xet://{username}/kickstart_ml/{branch}/metrics/results.csv")))
+    results.append(pd.read_csv(pyxet.open(f"xet://xethub.com:{username}/kickstart_ml/{branch}/metrics/results.csv")))
 
 df = pd.concat(results)
 df = df[df['target']=='weighted avg']
@@ -287,7 +287,7 @@ import pyxet
 fs = pyxet.XetFS()
 with fs.transaction as tr:
     tr.set_commit_message("Adding more data")
-    fs.cp("data/titanic.csv", "xet://${XET_USER_NAME}/kickstart_data/main/titanic2.csv")
+    fs.cp("data/titanic.csv", "xet://xethub.com:${XET_USER_NAME}/kickstart_data/main/titanic2.csv")
 ```
 
 We can have any naming convention for our ”training-cycle-jobs” branches.

--- a/docs/markdowns/model_versioning_tutorial.md
+++ b/docs/markdowns/model_versioning_tutorial.md
@@ -64,7 +64,7 @@ datasets, XetHub can hold any type of file: A/B test data, databases backup dump
 ```python
 import pyxet
 
-fs = pyxet.XetFS()
+fs = pyxet.XetFS('xethub.com')
 
 # a transaction is needed for write
 with fs.transaction as tr:
@@ -130,7 +130,7 @@ To save time, we simply copy it from a ready *app* branch.
 ```python
 import pyxet
 
-fs = pyxet.XetFS()
+fs = pyxet.XetFS('xethub.com')
 fs.cp("xdssio/kickstart_ml/app/server", "server")
 ```
 
@@ -200,7 +200,7 @@ To get the full code… we’ll copy it from the existing version:
 ```python
 import pyxet
 
-fs = pyxet.XetFS()
+fs = pyxet.XetFS('xethub.com')
 
 fs.cp("xdssio/titanic/experiment1/notebooks/train.ipynb", "notebooks/train.ipynb")
 ```
@@ -284,7 +284,7 @@ We simulate it by just adding data there:
 ```python
 import pyxet
 
-fs = pyxet.XetFS()
+fs = pyxet.XetFS('xethub.com')
 with fs.transaction as tr:
     tr.set_commit_message("Adding more data")
     fs.cp("data/titanic.csv", "xet://xethub.com:${XET_USER_NAME}/kickstart_data/main/titanic2.csv")

--- a/docs/markdowns/mount.md
+++ b/docs/markdowns/mount.md
@@ -10,15 +10,16 @@ SQLite and Parquet databases.
 
 To mount:
 ```bash
-xet mount xet://<username>/<repo>/<branch> <local_path>
+xet mount xet://<endpoint>:<username>/<repo>/<branch> <local_path>
 ```
 
-On windows, the `local_path` must be a drive letter. For instance `X:`
+Use our public `xethub.com` endpoint unless you're on a custom enterprise deployment
+On Windows, the `local_path` must be a drive letter. For instance `X:`
 
 For instance, you can mount the Flickr30k dataset with:
 
 ```bash
-xet mount xet://XetHub/Flickr30k/main Flickr30k
+xet mount xet://xethub.com:XetHub/Flickr30k/main Flickr30k
 ```
 And you will be able to browse to it and explore its contents.
 
@@ -26,7 +27,7 @@ And you will be able to browse to it and explore its contents.
 
 As a slightly larger example, you can mount the Laion400M metadata (54GB) with 
 ```bash
-xet mount --prefetch 0 xet://XetHub/LAION-400M/main LAION400M 
+xet mount --prefetch 0 xet://xethub.com:XetHub/LAION-400M/main LAION400M 
 cd LAION400M
 ```
 which provides a collection of Parquet files which you can query

--- a/docs/markdowns/quickstart.md
+++ b/docs/markdowns/quickstart.md
@@ -104,7 +104,7 @@ Here are some simple ways to access information from an existing repository:
 ```python
 import pyxet
 
-fs = pyxet.XetFS()  # fsspec filesystem
+fs = pyxet.XetFS('xethub.com')  # fsspec filesystem with endpoint specified
 
 fs.info("XetHub/titanic/main/titanic.csv")  
 # returns repo level info: {'name': 'XetHub/main/titanic.csv', 'size': 61194, 'type': 'file'}

--- a/docs/markdowns/quickstart.md
+++ b/docs/markdowns/quickstart.md
@@ -59,7 +59,7 @@ Python fsspec.
 import pyxet            # make xet:// protocol available
 import pandas as pd     # assumes pip install pandas has been run
 
-df = pd.read_csv('xet://XetHub/titanic/main/titanic.csv')
+df = pd.read_csv('xet://xethub.com:XetHub/titanic/main/titanic.csv')
 df
 ```
 
@@ -90,8 +90,10 @@ leveraging the power of Git branches and versioning.
 
 A XetHub URL for pyxet is in the form:
 ```
-xet://<repo_owner>/<repo_name>/<branch>/<path_to_file>
+xet://<endpoint>:<repo_owner>/<repo_name>/<branch>/<path_to_file>
 ```
+
+Use our public `xethub.com` endpoint unless you're on a custom enterprise deployment.
 
 Unlike with traditional blob stores, the ability to call a branch means that you can choose whether to 
 use the most recent version of a file/directory or to reference a particular branch or commit.

--- a/docs/markdowns/writing.md
+++ b/docs/markdowns/writing.md
@@ -10,7 +10,7 @@ Use the XetHub UI to [create a new repository](https://xethub.com/xet/create). N
 You can then create a branch called experiment-1 with
 
 ```
-xet branch make xet://<username>/titanic main experiment-1
+xet branch make xet://xethub.com:<username>/titanic main experiment-1
 ```
 
 Start a new virtualenv and install some dependencies:
@@ -31,7 +31,7 @@ from sklearn.model_selection import train_test_split
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.metrics import classification_report
 
-df = pd.read_csv("xet://XetHub/titanic/main/titanic.csv")  # read data from XetHub
+df = pd.read_csv("xet://xethub.com:XetHub/titanic/main/titanic.csv")  # read data from XetHub
 
 # Standard ML workflow
 target_names, features, target = ['die', 'survive'], ["Pclass", "SibSp", "Parch"], "Survived"
@@ -92,7 +92,7 @@ model = pickle.load(fs.open("<user_name>/titanic/experiment-1/models/model.pickl
 Versioned experiments on branches enables easy comparison.
 To try this out, create a new `experiment-2` branch:
 ```sh
-xet branch make xet://<username>/titanic main experiment-2
+xet branch make xet://xethub.com:<username>/titanic main experiment-2
 ```
 
 Run the same code as above, but change the `test_size` and `random_state` values. This time, persist 
@@ -117,7 +117,7 @@ import pandas as pd
 
 dfs = []
 for branch in ['experiment-1', 'experiment-2']:
-    df = pd.read_csv(f"xet://<user_name>/titanic/{branch}/metrics/results.csv")
+    df = pd.read_csv(f"xet://xethub.com:<user_name>/titanic/{branch}/metrics/results.csv")
     df['branch'] = branch
     dfs.append(df)
 pd.concat(dfs)

--- a/docs/markdowns/writing.md
+++ b/docs/markdowns/writing.md
@@ -60,10 +60,10 @@ results = pd.DataFrame([{'accuracy': info['accuracy'],
 ### Writing back to XetHub
 
 After training your model, you can persist both the model and metrics back to XetHub.
-Update the `<user_name>` fields below and run:
+Update the `<user_name>` fields below and run the following, which assumes that you're using our public xethub.com endpoint:
 
 ```python
-fs = pyxet.XetFS()
+fs = pyxet.XetFS('xethub.com')
 with fs.transaction as tr:
     tr.set_commit_message("Write experiment 1 results back to repo")
     fs.mkdirs("<user_name>/titanic/experiment-1/metrics", exist_ok=True)

--- a/python/pyxet/pyxet/__init__.py
+++ b/python/pyxet/pyxet/__init__.py
@@ -20,7 +20,8 @@ Main features:
 
 To open a file from a XetHub repository, you can use the `pyxet.open()` 
 function, which takes a file URL in the format 
-`xet://<repo_user>/<repo_name>/<branch>/<path-to-file>`.  (See below for the URL format).
+`xet://<endpoint>:<repo_user>/<repo_name>/<branch>/<path-to-file>`. 
+Use our public `xethub.com` endpoint unless you're on a custom enterprise deployment.
 
 Example usage of `pyxet.open`:
 
@@ -29,7 +30,7 @@ import pyxet
 
 # Open a file from a public repository.
 
-f = pyxet.open('XetHub/Flickr30k/main/results.csv')
+f = pyxet.open('xethub.com:XetHub/Flickr30k/main/results.csv')
 
 # Read the contents of the file.
 contents = f.read()
@@ -49,10 +50,10 @@ import pyxet
 fs = pyxet.XetFS()
 
 # List files in the repository.
-files = fs.ls('XetHub/Flickr30k/main')
+files = fs.ls('xethub.com:XetHub/Flickr30k/main')
 
 # Open a file from the repository.
-f = fs.open('XetHub/Flick30k/main/results.csv')
+f = fs.open('xethub.com:XetHub/Flick30k/main/results.csv')
 
 # Read the contents of the file.
 contents = f.read()
@@ -70,14 +71,14 @@ a XetHub repository.  For example, to read a csv from pandas, use:
 
 ```
 import pyxet
-csv = pd.read_csv('xet://XetHub/Flickr30k/main/results.csv')
+csv = pd.read_csv('xet://xethub.com:XetHub/Flickr30k/main/results.csv')
 ```
 
 URLs:
 -----
 
-Xet URLs should be of the form `xet://<repo_user>/<repo_name>/<branch>/<path-to-file>`,
-with the <path-to-file> being optional when opening a repository.  
+Xet URLs should be of the form `xet://<endpoint>:<repo_user>/<repo_name>/<branch>/<path-to-file>`,
+with the <path-to-file> being optional when opening a repository and `xethub.com` as the public endpoint.  
 The xet:// prefix is inferred as needed or if the url is given as https://.  
 If branch is given as an explicit argument, it may be committed 
 from the url.  

--- a/python/pyxet/pyxet/cli.py
+++ b/python/pyxet/pyxet/cli.py
@@ -55,7 +55,7 @@ class PyxetCLI:
         """
         source = parse_url(source)
         if source.path != '':
-            raise ValueError("Cannot have a path when mounting. Expecting xet://[user]/[repo]/[branch]")
+            raise ValueError("Cannot have a path when mounting. Expecting xet://domain:user/repo/branch")
         if source.branch == '':
             raise ValueError("Branch or revision must be specified")
         if os.name == 'nt':


### PR DESCRIPTION
Ok, based on Hoyt's linear issue, which talks about endpoints, I updated docs in xethub/ and readthedocs here to talk about endpoints. Fixes PRO-46.

In looking for references, I am seeing now that there is inconsistent references in pyxet docs and docstrings. In a git grep of the pyxet repo for `xet://`, I see things like:
```
python/pyxet/pyxet/cli.py:            print("Please specify a valid repository name in format xet://domain:user/repo")
python/pyxet/pyxet/cli.py:            listing = [{'name': "xet://" + path + '/' + n['name'], 'type': 'branch'} for n in listing]
python/pyxet/pyxet/cli.py:    def delete(repo: Annotated[str, typer.Argument(help="Repository name in format xet://domain:user/repo")],
python/pyxet/pyxet/cli.py:                print("Please specify a valid repository name xet://[user]/[repo]")
python/pyxet/pyxet/cli.py:    def info(repo: Annotated[str, typer.Argument(help="Repository name in format xet://domain:user/repo")],
python/pyxet/pyxet/cli.py:            print("Please specify a valid repository name in format xet://[user]/[repo]")
python/pyxet/pyxet/cli.py:    def make(name: Annotated[str, typer.Argument(help="Repository name in format xet://domain:user/repo")],
python/pyxet/pyxet/cli.py:            xet_path = f'xet://{path_split}'
python/pyxet/pyxet/cli.py:        Forks a copy of a repository from xet://[user]/[repo] to your own account.
python/pyxet/pyxet/cli.py:        If dest is not provided, xet://[yourusername]/[repo] is used.
python/pyxet/pyxet/cli.py:            dest = "xet://" + fs.get_username() + "/" + repo_name
python/pyxet/pyxet/cli.py:    def ls(uri: Annotated[str, typer.Argument(help="A URI in format xet://domain:user")],
python/pyxet/pyxet/cli.py:    def rename(source: Annotated[str, typer.Argument(help="Origin repo to rename from in format xet://domain:user/repo)")],
python/pyxet/pyxet/cli.py:               dest: Annotated[str, typer.Argument(help="Repo to rename to in format xet://domain:user/repo")]):
python/pyxet/pyxet/cli.py:    def clone(source: Annotated[str, typer.Argument(help="Repository in format xet://domain:user/repo")],
python/pyxet/pyxet/cli.py:    def info(uri: Annotated[str, typer.Argument(help="A URI in format xet://[user]/[repo]")]):
python/pyxet/pyxet/file_system.py:    of the form `xet://<repo_user>/<repo_name>/<branch>/<path-to-file>`::
python/pyxet/pyxet/file_system.py:        f = pyxet.open('xet://XetHub/Flickr30k/main/results.csv')
python/pyxet/pyxet/file_system.py:    protocol = "xet"  # This allows pandas, etc. to implement "xet://"
python/pyxet/pyxet/file_system.py:        if path.startswith('xet://'):
python/pyxet/pyxet/file_system.py:        return 'xet://' + name.lstrip('/')
python/pyxet/pyxet/file_system.py:        or `xet://user/repo/branch`
python/pyxet/pyxet/file_system.py:        or `xet://user/repo/branch/[path]`
python/pyxet/pyxet/file_system.py:        src_name = 'xet://' + ret['full_name']
python/pyxet/pyxet/file_system.py:        Lists the repos available for a path of the form `user` or `xet://user`
python/pyxet/pyxet/file_system.py:        Lists the branches for a path of the form `user/repo` or `xet://user/repo`
python/pyxet/pyxet/file_system.py:            # xet://domain:/
python/pyxet/pyxet/file_system.py:        `user/repo/branch` or `xet://user/repo/branch`::
python/pyxet/pyxet/sync.py:            raise ValueError(f"Unsupported destination protocol: {self._dest_proto}, only xet:// targets are supported")
python/pyxet/pyxet/url_parsing.py:                            "          xet://<endpoint>:<user>/<repo>/<branch>/<path>.\n")
python/pyxet/pyxet/url_parsing.py:     - xet://user/repo/branch/[path]
python/pyxet/pyxet/url_parsing.py:    parse /user or xet://user
python/pyxet/pyxet/url_parsing.py:        raise ValueError(f"URL {url} not of the form xet://endpoint:user/repo/...")
python/pyxet/pyxet/url_parsing.py:    # Handle the case where we are xet://user/repo. In which case the domain
python/pyxet/pyxet/url_parsing.py:            sys.stderr.write("Warning:  The use of the xet:// prefix without an endpoint is deprecated and will be disabled in the future.\n"
python/pyxet/pyxet/url_parsing.py:                             "          Please switch URLs to use the format xet://<endpoint>:<user>/<repo>/<branch>/<path>.\n"
```

Note these inconsistencies:
- The endpoint is sometimes not even mentioned, sometimes referred to as "domain", and sometimes referred to as "endpoint".
- URLs are sometimes referenced with brackets `[]` and sometimes without. 

I updated the docs to use "endpoint" consistently. If it makes sense (I didn't check to see if these are in comments or user-facing), could @hoytak or @seanses please open a new PR to go through the rest of the code files and make sure that we are (P1) consistently asking users to use "endpoint" throughout and (P3) potentially standardizing how we are composing URLs? From what I see of the grep, this looks pretty messy.