### PR TITLE
Consistent doc strings and error messages for xet:// URLs

### DIFF
--- a/python/pyxet/pyxet/__init__.py
+++ b/python/pyxet/pyxet/__init__.py
@@ -20,8 +20,8 @@ Main features:
 
 To open a file from a XetHub repository, you can use the `pyxet.open()` 
 function, which takes a file URL in the format 
-`xet://<endpoint>:<repo_user>/<repo_name>/<branch>/<path-to-file>`. 
-Use our public `xethub.com` endpoint unless you're on a custom enterprise deployment.
+`xet://<domain>:<repo_user>/<repo_name>/<branch>/<path-to-file>`. 
+Use our public `xethub.com` domain unless you're on a custom enterprise deployment.
 
 Example usage of `pyxet.open`:
 
@@ -77,8 +77,8 @@ csv = pd.read_csv('xet://xethub.com:XetHub/Flickr30k/main/results.csv')
 URLs:
 -----
 
-Xet URLs should be of the form `xet://<endpoint>:<repo_user>/<repo_name>/<branch>/<path-to-file>`,
-with the <path-to-file> being optional when opening a repository and `xethub.com` as the public endpoint.  
+Xet URLs should be of the form `xet://<domain>:<repo_user>/<repo_name>/<branch>/<path-to-file>`,
+with the <path-to-file> being optional when opening a repository and `xethub.com` as the public domain.  
 The xet:// prefix is inferred as needed or if the url is given as https://.  
 If branch is given as an explicit argument, it may be committed 
 from the url.  

--- a/python/pyxet/pyxet/__init__.py
+++ b/python/pyxet/pyxet/__init__.py
@@ -20,8 +20,8 @@ Main features:
 
 To open a file from a XetHub repository, you can use the `pyxet.open()` 
 function, which takes a file URL in the format 
-`xet://<domain>:<repo_user>/<repo_name>/<branch>/<path-to-file>`. 
-Use our public `xethub.com` domain unless you're on a custom enterprise deployment.
+`xet://<endpoint>:<repo_user>/<repo_name>/<branch>/<path-to-file>`. 
+Use our public `xethub.com` endpoint unless you're on a custom enterprise deployment.
 
 Example usage of `pyxet.open`:
 
@@ -77,8 +77,8 @@ csv = pd.read_csv('xet://xethub.com:XetHub/Flickr30k/main/results.csv')
 URLs:
 -----
 
-Xet URLs should be of the form `xet://<domain>:<repo_user>/<repo_name>/<branch>/<path-to-file>`,
-with the <path-to-file> being optional when opening a repository and `xethub.com` as the public domain.  
+Xet URLs should be of the form `xet://<endpoint>:<repo_user>/<repo_name>/<branch>/<path-to-file>`,
+with the <path-to-file> being optional when opening a repository and `xethub.com` as the public endpoint.  
 The xet:// prefix is inferred as needed or if the url is given as https://.  
 If branch is given as an explicit argument, it may be committed 
 from the url.  

--- a/python/pyxet/pyxet/cli.py
+++ b/python/pyxet/pyxet/cli.py
@@ -289,14 +289,14 @@ class PyxetCLI:
                   public: Annotated[bool, typer.Option('--public', help="make repository public")] = False,
                   ):
         """
-        Duplicates (via a detached fork) a copy of a repository from xet://[user]/[repo] to your own account.
+        Duplicates (via a detached fork) a copy of a repository from xet://[domain]:[user]/[repo] to your own account.
         Defaults to original repository private/public settings. Use --private or --public to adjust the repository permissions. 
-        If dest is not provided, xet://[yourusername]/[repo] is used.
+        If dest is not provided, xet://[domain]:[yourusername]/[repo] is used.
         Use `xet fork` if you want a regular fork.
         """
         source = parse_url(source, expect_repo=True, expect_branch= False)
         if not source.domain == dest.domain:
-            print("Both repos must have the same endpoint.")
+            print("Both repos must have the same domain.")
             return
 
         fs = XetFS(domain = source.domain)
@@ -349,7 +349,7 @@ class BranchCLI:
 
     @staticmethod
     @branch.command()
-    def ls(repo: Annotated[str, typer.Argument(help="Repository name in format xet://domain:user/repo")],
+    def ls(repo: Annotated[str, typer.Argument(help="Repository name in format xet://<domain>:<user>/<repo>")],
            raw: Annotated[bool, typer.Option(help="If True, will print the raw JSON output")] = False):
         """
         list branches of a repository.
@@ -372,7 +372,7 @@ class BranchCLI:
 
     @staticmethod
     @branch.command()
-    def delete(repo: Annotated[str, typer.Argument(help="Repository name in format xet://domain:user/repo")],
+    def delete(repo: Annotated[str, typer.Argument(help="Repository name in format xet://<domain>:<user>/<repo>")],
                branch: Annotated[str, typer.Argument(help="Branch to delete")],
                yes: Annotated[bool, typer.Option(help="Type yes to delete")] = False):
         """
@@ -388,7 +388,7 @@ class BranchCLI:
             print("--yes is set. Issuing deletion", file=sys.stderr)
             fs, path = _get_fs_and_path(repo)
             if fs.protocol != 'xet':
-                print("Please specify a valid repository name xet://[user]/[repo]")
+                print("Please specify a valid repository name using xet://<domain>:<user>/<repo>")
                 return
             return fs.delete_branch(repo, branch)
         else:
@@ -396,14 +396,14 @@ class BranchCLI:
 
     @staticmethod
     @branch.command()
-    def info(repo: Annotated[str, typer.Argument(help="Repository name in format xet://domain:user/repo")],
+    def info(repo: Annotated[str, typer.Argument(help="Repository name in format xet://<domain>:<user>/<repo>")],
              branch: Annotated[str, typer.Argument(help="Branch to query")]):
         """
         Prints information about a branch
         """
         fs, path = _get_fs_and_path(repo)
         if fs.protocol != 'xet':
-            print("Please specify a valid repository name in format xet://[user]/[repo]")
+            print("Please specify a valid repository name in format xet://<domain>:<user>/<repo>")
             return
         ret = fs.find_ref(repo, branch)
         print(ret)
@@ -413,7 +413,7 @@ class BranchCLI:
 class RepoCLI:
     @staticmethod
     @repo.command()
-    def make(name: Annotated[str, typer.Argument(help="Repository name in format xet://domain:user/repo")],
+    def make(name: Annotated[str, typer.Argument(help="Repository name in format xet://<domain>:<user>/<repo>")],
              private: Annotated[bool, typer.Option('--private', help="Make repository private")] = False,
              public: Annotated[bool, typer.Option('--public', help="Make repository public")] = False,
              raw: Annotated[bool, typer.Option('--raw', help="Raw output")] = False,
@@ -446,9 +446,9 @@ class RepoCLI:
              dest: Annotated[str, typer.Argument(help="New repository name")] = None,
              ):
         """
-        Forks a copy of a repository from xet://[user]/[repo] to your own account.
+        Forks a copy of a repository from xet://<domain>:<user>/<repo> to your own account.
         Defaults to original repository private/public settings. 
-        If dest is not provided, xet://[yourusername]/[repo] is used.
+        If dest is not provided, xet://<domain>:<yourusername>/<repo> is used.
         Use `xet duplicate` if you want a detached private fork.
         """
 
@@ -462,7 +462,7 @@ class RepoCLI:
 
     @staticmethod
     @repo.command()
-    def ls(uri: Annotated[str, typer.Argument(help="A URI in format xet://domain:user")],
+    def ls(uri: Annotated[str, typer.Argument(help="A URI in format xet://<domain>:<user>")],
            raw: Annotated[bool, typer.Option(help="If True, will print the raw JSON output")] = False):
         """
         list repositories of a user.
@@ -481,17 +481,17 @@ class RepoCLI:
 
     @staticmethod
     @repo.command()
-    def rename(source: Annotated[str, typer.Argument(help="Origin repo to rename from in format xet://domain:user/repo)")],
-               dest: Annotated[str, typer.Argument(help="Repo to rename to in format xet://domain:user/repo")]):
+    def rename(source: Annotated[str, typer.Argument(help="Origin repo to rename from in format xet://<domain>:<user>/<repo>)")],
+               dest: Annotated[str, typer.Argument(help="Repo to rename to in format xet://<domain>:<user>/<repo>")]):
         """
-        Forks a new repository from an existing repository.
+        Renames a repository.
         """
         fs = XetFS.from_url(source)
         fs.rename_repo(source, dest)
 
     @staticmethod
     @repo.command()
-    def clone(source: Annotated[str, typer.Argument(help="Repository in format xet://domain:user/repo")],
+    def clone(source: Annotated[str, typer.Argument(help="Repository in format xet://<domain>:<user>/<repo>")],
               args: Annotated[typing.List[str], typer.Argument(help="Arguments to be passed to git-xet clone")] = None):
         """
         Clones a repository on a local path
@@ -500,7 +500,7 @@ class RepoCLI:
 
     @staticmethod
     @repo.command()
-    def info(uri: Annotated[str, typer.Argument(help="A URI in format xet://[user]/[repo]")]):
+    def info(uri: Annotated[str, typer.Argument(help="A URI in format xet://<domain>:<user>/<repo>")]):
         """
         provide information on the repo\n
 

--- a/python/pyxet/pyxet/file_operations.py
+++ b/python/pyxet/pyxet/file_operations.py
@@ -40,8 +40,8 @@ def _validate_xet_copy(src_fs, src_path, dest_fs, dest_path):
         # exists before we try to do any copying
         # An exception is that if this operation would create a branch
         if srcproto == 'xet':
-            src_parse = parse_url(src_path, src_fs.domain)
-            dest_parse = parse_url(dest_path, dest_fs.domain)
+            src_parse = parse_url(src_path, src_fs.endpoint)
+            dest_parse = parse_url(dest_path, dest_fs.endpoint)
             if src_parse.path == '' and dest_parse.path == '':
                 # this is a branch to branch copy
                 return True

--- a/python/pyxet/pyxet/file_system.py
+++ b/python/pyxet/pyxet/file_system.py
@@ -105,7 +105,7 @@ class XetFS(fsspec.spec.AbstractFileSystem):
             # Read the first 5 lines of a file
             b = fs.open('XetHub/Flickr30k/main/results.csv').read()
 
-        the Xet repository endpoint can be set with the 'domain' argument
+        the Xet repository domain can be set with the 'domain' argument
         or the XET_ENDPOINT environment variable. The default domain is
         xethub.com if unspecified
         """
@@ -269,11 +269,12 @@ class XetFS(fsspec.spec.AbstractFileSystem):
 
         if 'full_name' not in ret:
             raise RuntimeError("Duplication failed")
-        src_name = 'xet://' + ret['full_name']
-        if src_name == dest_path:
+        ret_name = 'xet://' + ret['full_name']
+        ret_info = parse_url(ret_name, self.domain, expect_branch=False)
+        if ret_info == dest:
             return ret
 
-        return self.rename_repo(src_name, dest_path)
+        return self.rename_repo(ret_name, dest_path)
 
     def rename_repo(self, origin_path, dest_path, **kwargs):
         origin = parse_url(origin_path, self.domain, expect_branch = False)

--- a/python/pyxet/pyxet/file_system.py
+++ b/python/pyxet/pyxet/file_system.py
@@ -58,9 +58,11 @@ def login(user, token, email=None, host=None):
 def open(file_url, mode="rb", **kwargs):
     """
     Open the file at the specific Xet file URL
-    of the form `xet://<repo_user>/<repo_name>/<branch>/<path-to-file>`::
+    of the form `xet://<domain>:<user>/<repo>/<branch>/<path-to-file>`.  
 
-        f = pyxet.open('xet://XetHub/Flickr30k/main/results.csv')
+    For example::
+
+        f = pyxet.open('xet://xethub.com:XetHub/Flickr30k/main/results.csv')
     """
 
     url_info = parse_url(file_url, expect_branch=True)
@@ -179,7 +181,7 @@ class XetFS(fsspec.spec.AbstractFileSystem):
     def branch_info(self, url):
         """
         Returns information about a branch `user/repo/branch` 
-        or `xet://user/repo/branch`
+        or `xet://[domain:]<user>/<repo>/<branch>`
         """
         # try to parse this as a URL
         # and if not try to parse it as a path
@@ -210,7 +212,7 @@ class XetFS(fsspec.spec.AbstractFileSystem):
     def info(self, url):
         """
         Returns information about a path `user/repo/branch/[path]` 
-        or `xet://user/repo/branch/[path]`
+        or `xet://[domain:]<user>/<repo>/<branch>/[path]`
         """
         url_path = parse_url(url, self.domain, expect_branch = True)
         attr = self._manager.stat(url_path.remote(), url_path.branch, url_path.path)
@@ -303,7 +305,7 @@ class XetFS(fsspec.spec.AbstractFileSystem):
 
     def list_repos(self, url, raw=False, **kwargs):
         """
-        Lists the repos available for a path of the form `user` or `xet://user`
+        Lists the repos available for a path of the form `user` or `xet://[domain:]<user>`
         """
         remote = parse_url(url, self.domain, expect_branch=False, expect_repo=False)
 
@@ -316,7 +318,7 @@ class XetFS(fsspec.spec.AbstractFileSystem):
 
     def list_branches(self, path, raw=False, **kwargs):
         """
-        Lists the branches for a path of the form `user/repo` or `xet://user/repo`
+        Lists the branches for a path of the form `user/repo` or `xet://[domain:]<user>/<repo>`
         """
         url_path = parse_url(path, self.domain, expect_branch=False)
         res = json.loads(bytes(self._manager.api_query(url_path.remote(), "branches", "get", "")))
@@ -644,7 +646,7 @@ class XetFS(fsspec.spec.AbstractFileSystem):
 
             with fs.transaction as tr:
                 tr.set_commit_message("message")
-                file = fs.open('user/repo/main/hello.txt','w')
+                file = fs.open('<user>/<repo>/main/hello.txt','w')
                 file.write('hello world')
                 file.close()
 
@@ -669,7 +671,7 @@ class XetFS(fsspec.spec.AbstractFileSystem):
         transaction. All writes must be performed into this branch
 
         repo_and_branch is of the form
-        `user/repo/branch` or `xet://user/repo/branch`::
+        `<user>/<repo>/<branch>` or `xet://[domain:]<user>/<repo>/<branch>`::
 
             fs.start_transaction('my commit message')
             file = fs.open('user/repo/main/hello.txt','w')

--- a/python/pyxet/pyxet/url_parsing.py
+++ b/python/pyxet/pyxet/url_parsing.py
@@ -140,7 +140,7 @@ def parse_url(url, default_domain=None, expect_branch = None, expect_repo = True
 
     if scheme not in ["xet", "http", "https"]: 
         # The other 
-        raise ValueError(f"URL {url} not of the form xet://domain:user/repo/...")
+        raise ValueError(f"URL {url} not of the form xet://<domain>:<user>/<repo>/...")
 
 
     # Set this as a default below     
@@ -198,19 +198,19 @@ def parse_url(url, default_domain=None, expect_branch = None, expect_repo = True
     components += list([t for t in [t.strip() for t in path_to_parse.split('/')] if t])
 
     if len(components) == 0:
-        raise ValueError(f"Invalid Xet URL format; user must be specified. Expecting xet://domain:user/[repo/[branch[/path]]], got {url}")
+        raise ValueError(f"Invalid Xet URL format; user must be specified. Expecting xet://<domain>:<user>/[repo/[branch[/path]]], got {url}")
     
     if len(components) == 1 and expect_repo is True:
-        raise ValueError(f"Invalid Xet URL format; user and repo must be specified. Expecting xet://domain:user/repo/[branch[/path]], got {url}")
+        raise ValueError(f"Invalid Xet URL format; user and repo must be specified. Expecting xet://<domain>:<user>/<repo>/[branch[/path]], got {url}")
     
     if len(components) > 1 and expect_repo is False:
-        raise ValueError(f"Invalid Xet URL format for user; repo given.  Expecting xet://domain:user/, got {url}")
+        raise ValueError(f"Invalid Xet URL format for user; repo given.  Expecting xet://<domain>:<user>/, got {url}")
        
     if len(components) == 2 and expect_branch is True:
-        raise ValueError(f"Invalid Xet URL format; user, repo, and branch must be specified for this operation. Expecting xet://domain:user/repo/branch[/path], got {url}")
+        raise ValueError(f"Invalid Xet URL format; user, repo, and branch must be specified for this operation. Expecting xet://<domain>:<user>/<repo>/<branch>[/path], got {url}")
 
     if len(components) > 2 and expect_branch is False:
-        raise ValueError(f"Invalid Xet URL format for repo; branch given.  Expecting xet://domain:user/repo, got {url}")
+        raise ValueError(f"Invalid Xet URL format for repo; branch given.  Expecting xet://<domain>:<user>/<repo>, got {url}")
 
     
     ret.user = components[0]

--- a/python/pyxet/pyxet/url_parsing.py
+++ b/python/pyxet/pyxet/url_parsing.py
@@ -24,7 +24,7 @@ def get_default_domain():
         domain = __default_domain = env_domain
     else:
         sys.stderr.write("\nWarning:  Endpoint defaulting to xethub.com; use URLs of the form \n"
-                            "          xet://<endpoint>:<user>/<repo>/<branch>/<path>.\n")
+                            "          xet://<domain>:<user>/<repo>/<branch>/<path>.\n")
         domain = __default_domain = "xethub.com"
 
     return domain 
@@ -69,7 +69,7 @@ class XetPathInfo:
 
     def remote(self, domain_only = False):
         """
-        Returns the endpoint of this in the qualified user[:token]@domain
+        Returns the domain of this in the qualified user[:token]@domain
         """
         if domain_only:
             ret = f"https://{self.domain}/"
@@ -140,7 +140,7 @@ def parse_url(url, default_domain=None, expect_branch = None, expect_repo = True
 
     if scheme not in ["xet", "http", "https"]: 
         # The other 
-        raise ValueError(f"URL {url} not of the form xet://endpoint:user/repo/...")
+        raise ValueError(f"URL {url} not of the form xet://domain:user/repo/...")
 
 
     # Set this as a default below     
@@ -164,8 +164,8 @@ def parse_url(url, default_domain=None, expect_branch = None, expect_repo = True
         global has_warned_user_on_url_format
 
         if default_domain is None and not has_warned_user_on_url_format:
-            sys.stderr.write("Warning:  The use of the xet:// prefix without an endpoint is deprecated and will be disabled in the future.\n"
-                             "          Please switch URLs to use the format xet://<endpoint>:<user>/<repo>/<branch>/<path>.\n"
+            sys.stderr.write("Warning:  The use of the xet:// prefix without an domain is deprecated and will be disabled in the future.\n"
+                             "          Please switch URLs to use the format xet://<domain>:<user>/<repo>/<branch>/<path>.\n"
                              "          Endpoint now defaulting to xethub.com.\n\n")
             has_warned_user_on_url_format = True
         
@@ -188,7 +188,7 @@ def parse_url(url, default_domain=None, expect_branch = None, expect_repo = True
             if not ret.domain:
                 ret.domain = default_domain
         else: 
-            raise ValueError(f"Cannot parse user and endpoint from {netloc}")
+            raise ValueError(f"Cannot parse user and domain from {netloc}")
         
         ret.domain_explicit = True
 

--- a/python/pyxet/pyxet/url_parsing.py
+++ b/python/pyxet/pyxet/url_parsing.py
@@ -8,91 +8,91 @@ import os
 
 has_warned_user_on_url_format = False
 
-__default_domain = None
+__default_endpoint = None
 
-def set_default_domain(domain): 
-    global __default_domain
-    if __default_domain is None:
-        __default_domain = normalize_domain(domain) 
+def set_default_endpoint(endpoint): 
+    global __default_endpoint
+    if __default_endpoint is None:
+        __default_endpoint = normalize_endpoint(endpoint) 
 
-def get_default_domain():
-    global __default_domain
-    if __default_domain is not None:
-        domain = __default_domain
+def get_default_endpoint():
+    global __default_endpoint
+    if __default_endpoint is not None:
+        endpoint = __default_endpoint
     elif "XET_ENDPOINT" in os.environ:
-        env_domain = os.environ["XET_ENDPOINT"]
-        domain = __default_domain = env_domain
+        env_endpoint = os.environ["XET_ENDPOINT"]
+        endpoint = __default_endpoint = env_endpoint
     else:
         sys.stderr.write("\nWarning:  Endpoint defaulting to xethub.com; use URLs of the form \n"
-                            "          xet://<domain>:<user>/<repo>/<branch>/<path>.\n")
-        domain = __default_domain = "xethub.com"
+                            "          xet://<endpoint>:<user>/<repo>/<branch>/<path>.\n")
+        endpoint = __default_endpoint = "xethub.com"
 
-    return domain 
+    return endpoint 
 
 
-def normalize_domain(domain = None):
-    global __default_domain
-    if domain is None:
-        return get_default_domain()
+def normalize_endpoint(endpoint = None):
+    global __default_endpoint
+    if endpoint is None:
+        return get_default_endpoint()
 
-    # support default_domain with a scheme (http/https)
-    if domain is not None:
-        domain_split = domain.split('://')
-        if len(domain_split) == 1:
-            domain = domain_split[0]
-        elif len(domain_split) == 2:
-            domain = domain_split[1]
+    # support default_endpoint with a scheme (http/https)
+    if endpoint is not None:
+        endpoint_split = endpoint.split('://')
+        if len(endpoint_split) == 1:
+            endpoint = endpoint_split[0]
+        elif len(endpoint_split) == 2:
+            endpoint = endpoint_split[1]
         else:
-            raise ValueError(f"Domain {domain} not valid url.")
+            raise ValueError(f"Domain {endpoint} not valid url.")
 
-    return domain
+    return endpoint
 
 
 class XetPathInfo:
-    __slots__ = ['scheme', 'domain', 'user', 'repo', 'branch', 'path', 'domain_explicit']
+    __slots__ = ['scheme', 'endpoint', 'user', 'repo', 'branch', 'path', 'endpoint_explicit']
 
     def _repo_branch_path(self):
         return "/".join(s for s in [self.repo, self.branch, self.path] if s)
 
     def url(self):
-        return f"{self.scheme}://{self.domain}:{self.user}/{self._repo_branch_path()}"
+        return f"{self.scheme}://{self.endpoint}:{self.user}/{self._repo_branch_path()}"
 
     def base_path(self): 
         """
         Returns the base user/repo/branch  
         """ 
-        if self.domain_explicit:
-            return f"{self.domain}:{self.user}/{self.repo}/{self.branch}"
+        if self.endpoint_explicit:
+            return f"{self.endpoint}:{self.user}/{self.repo}/{self.branch}"
         else:
             return f"{self.user}/{self.repo}/{self.branch}"
 
 
-    def remote(self, domain_only = False):
+    def remote(self, endpoint_only = False):
         """
-        Returns the domain of this in the qualified user[:token]@domain
+        Returns the endpoint of this in the qualified user[:token]@endpoint
         """
-        if domain_only:
-            ret = f"https://{self.domain}/"
+        if endpoint_only:
+            ret = f"https://{self.endpoint}/"
         elif self.repo:
-            ret = f"https://{self.domain}/{self.user}/{self.repo}"
+            ret = f"https://{self.endpoint}/{self.user}/{self.repo}"
         else:
-            ret = f"https://{self.domain}/{self.user}"
+            ret = f"https://{self.endpoint}/{self.user}"
 
         # This should work but has issues in xet-core
         #if branch and self.branch:
-        #    ret = f"https://{self._user_at_domain()}/{self.repo}/{self.branch}"
+        #    ret = f"https://{self._user_at_endpoint()}/{self.repo}/{self.branch}"
         #elif self.repo:
-        #    ret = f"https://{self._user_at_domain()}/{self.repo}"
+        #    ret = f"https://{self._user_at_endpoint()}/{self.repo}"
         #else:
-        #    ret = f"https://{self._user_at_domain()}"
+        #    ret = f"https://{self._user_at_endpoint()}"
         
         return ret
     
-    def domain_url(self):
+    def endpoint_url(self):
         """
-        https://domain:user/
+        https://endpoint:user/
         """
-        return f"https://{self.domain}" 
+        return f"https://{self.endpoint}" 
 
     def name(self):
         """
@@ -102,7 +102,7 @@ class XetPathInfo:
 
     def __eq__(self, other: object) -> bool:
         return (self.scheme == other.scheme
-                and self.domain == other.domain
+                and self.endpoint == other.endpoint
                 and self.user == other.user
                 and self.repo == other.repo
                 and self.branch == other.branch
@@ -112,13 +112,13 @@ class XetPathInfo:
         return self.url()
 
 
-def parse_url(url, default_domain=None, expect_branch = None, expect_repo = True):
+def parse_url(url, default_endpoint=None, expect_branch = None, expect_repo = True):
     """
     Parses a Xet URL of the form 
      - xet://user/repo/branch/[path]
      - /user/repo/branch/[path]
 
-    Into a XetPathInfo which forms it as remote=https://[domain]/user/repo
+    Into a XetPathInfo which forms it as remote=https://[endpoint]/user/repo
     branch=[branch] and path=[path].
 
     branches with '/' are not supported.
@@ -128,7 +128,7 @@ def parse_url(url, default_domain=None, expect_branch = None, expect_repo = True
     """
     url_info = url.split("://")
 
-    # assert default_domain is not None
+    # assert default_endpoint is not None
 
     if len(url_info) == 1: 
         scheme = "xet"
@@ -140,7 +140,7 @@ def parse_url(url, default_domain=None, expect_branch = None, expect_repo = True
 
     if scheme not in ["xet", "http", "https"]: 
         # The other 
-        raise ValueError(f"URL {url} not of the form xet://<domain>:<user>/<repo>/...")
+        raise ValueError(f"URL {url} not of the form xet://<endpoint>:<user>/<repo>/...")
 
 
     # Set this as a default below     
@@ -156,41 +156,41 @@ def parse_url(url, default_domain=None, expect_branch = None, expect_repo = True
     else:
         netloc, path = netloc_info
 
-    # Handle the case where we are xet://user/repo. In which case the domain
-    # parsed is not xethub.com and domain="user".
+    # Handle the case where we are xet://user/repo. In which case the endpoint
+    # parsed is not xethub.com and endpoint="user".
     # we rewrite the parse the handle this case early.
     if ":" not in netloc:
         
         global has_warned_user_on_url_format
 
-        if default_domain is None and not has_warned_user_on_url_format:
-            sys.stderr.write("Warning:  The use of the xet:// prefix without an domain is deprecated and will be disabled in the future.\n"
-                             "          Please switch URLs to use the format xet://<domain>:<user>/<repo>/<branch>/<path>.\n"
+        if default_endpoint is None and not has_warned_user_on_url_format:
+            sys.stderr.write("Warning:  The use of the xet:// prefix without an endpoint is deprecated and will be disabled in the future.\n"
+                             "          Please switch URLs to use the format xet://<endpoint>:<user>/<repo>/<branch>/<path>.\n"
                              "          Endpoint now defaulting to xethub.com.\n\n")
             has_warned_user_on_url_format = True
         
-        default_domain = normalize_domain(default_domain) 
+        default_endpoint = normalize_endpoint(default_endpoint) 
 
         # Test explicitly for the case where this is just xet://
         if netloc.endswith(".com"):  # Cheap way now to see if it's a website or not; we won't hit this with the new format.
-            ret.domain = netloc
+            ret.endpoint = netloc
             path_to_parse = path
         else:
-            ret.domain = default_domain 
+            ret.endpoint = default_endpoint 
             path_to_parse = f"{netloc}/{path}"
-        ret.domain_explicit = False
+        ret.endpoint_explicit = False
         explicit_user = None
     else:
-        domain_user = netloc.split(":")
-        if len(domain_user) == 2:
-            ret.domain, explicit_user  = domain_user
+        endpoint_user = netloc.split(":")
+        if len(endpoint_user) == 2:
+            ret.endpoint, explicit_user  = endpoint_user
             path_to_parse = f"{path}"
-            if not ret.domain:
-                ret.domain = default_domain
+            if not ret.endpoint:
+                ret.endpoint = default_endpoint
         else: 
-            raise ValueError(f"Cannot parse user and domain from {netloc}")
+            raise ValueError(f"Cannot parse user and endpoint from {netloc}")
         
-        ret.domain_explicit = True
+        ret.endpoint_explicit = True
 
     path_endswith_slash = path_to_parse.endswith("/")
 
@@ -198,19 +198,19 @@ def parse_url(url, default_domain=None, expect_branch = None, expect_repo = True
     components += list([t for t in [t.strip() for t in path_to_parse.split('/')] if t])
 
     if len(components) == 0:
-        raise ValueError(f"Invalid Xet URL format; user must be specified. Expecting xet://<domain>:<user>/[repo/[branch[/path]]], got {url}")
+        raise ValueError(f"Invalid Xet URL format; user must be specified. Expecting xet://<endpoint>:<user>/[repo/[branch[/path]]], got {url}")
     
     if len(components) == 1 and expect_repo is True:
-        raise ValueError(f"Invalid Xet URL format; user and repo must be specified. Expecting xet://<domain>:<user>/<repo>/[branch[/path]], got {url}")
+        raise ValueError(f"Invalid Xet URL format; user and repo must be specified. Expecting xet://<endpoint>:<user>/<repo>/[branch[/path]], got {url}")
     
     if len(components) > 1 and expect_repo is False:
-        raise ValueError(f"Invalid Xet URL format for user; repo given.  Expecting xet://<domain>:<user>/, got {url}")
+        raise ValueError(f"Invalid Xet URL format for user; repo given.  Expecting xet://<endpoint>:<user>/, got {url}")
        
     if len(components) == 2 and expect_branch is True:
-        raise ValueError(f"Invalid Xet URL format; user, repo, and branch must be specified for this operation. Expecting xet://<domain>:<user>/<repo>/<branch>[/path], got {url}")
+        raise ValueError(f"Invalid Xet URL format; user, repo, and branch must be specified for this operation. Expecting xet://<endpoint>:<user>/<repo>/<branch>[/path], got {url}")
 
     if len(components) > 2 and expect_branch is False:
-        raise ValueError(f"Invalid Xet URL format for repo; branch given.  Expecting xet://<domain>:<user>/<repo>, got {url}")
+        raise ValueError(f"Invalid Xet URL format for repo; branch given.  Expecting xet://<endpoint>:<user>/<repo>, got {url}")
 
     
     ret.user = components[0]

--- a/python/pyxet/pyxet/util.py
+++ b/python/pyxet/pyxet/util.py
@@ -45,7 +45,7 @@ def __get_fs_and_path(uri, strip_trailing_slash = True):
         print(f"Invalid URL: {uri}", file=sys.stderr)
     if split[0] == 'xet':
         url_info = parse_url(uri, expect_branch=None, expect_repo=None)
-        fs = XetFS(domain = url_info.domain)
+        fs = XetFS(endpoint = url_info.endpoint)
         fs, _path_normalize(fs, url_info.name(), strip_trailing_slash = strip_trailing_slash)
         # 
 

--- a/python/pyxet/src/lib.rs
+++ b/python/pyxet/src/lib.rs
@@ -194,11 +194,11 @@ pub fn perform_mount_curdir(
 #[pymethods]
 impl PyRepoManager {
     #[new]
-    pub fn new(domain : &str) -> PyResult<Self> {
+    pub fn new(endpoint : &str) -> PyResult<Self> {
     
-        // A bit of a hack here to make sure the domain gets passed in correctly, 
+        // A bit of a hack here to make sure the endpoint gets passed in correctly, 
         // but hopefully this should be
-        std::env::set_var("XET_ENDPOINT", domain); 
+        std::env::set_var("XET_ENDPOINT", endpoint); 
         let manager = XetRepoManager::new(None, None).map_err(anyhow_to_runtime_error)?;
         Ok(PyRepoManager {
             manager: RwLock::new(manager),
@@ -363,7 +363,7 @@ impl PyRepo {
         )
     }
 
-    /// Fetch shards that could be useful for dedup, according to the given domains.
+    /// Fetch shards that could be useful for dedup, according to the given endpoints.
     ///
     /// Endpoints are given as a list of (branch, path) tuples.  Shard hint fetches may be
     /// across branches.

--- a/python/pyxet/src/lib.rs
+++ b/python/pyxet/src/lib.rs
@@ -363,7 +363,7 @@ impl PyRepo {
         )
     }
 
-    /// Fetch shards that could be useful for dedup, according to the given endpoints.
+    /// Fetch shards that could be useful for dedup, according to the given domains.
     ///
     /// Endpoints are given as a list of (branch, path) tuples.  Shard hint fetches may be
     /// across branches.

--- a/python/pyxet/tests/url_parsing.py
+++ b/python/pyxet/tests/url_parsing.py
@@ -38,7 +38,7 @@ class TestUrlParsing(unittest.TestCase):
         self.assertEqual(parse.branch, "")
         self.assertEqual(parse.path, "")
 
-        parse = self.parse_url("xet://xethub.com/user/repo/branch", True, default_domain='xetbeta.com')
+        parse = self.parse_url("xet://xethub.com/user/repo/branch", True, default_endpoint='xetbeta.com')
         self.assertEqual(parse.remote(), "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "")
@@ -72,7 +72,7 @@ class TestUrlParsing(unittest.TestCase):
         self.assertEqual(parse.branch, "")
         self.assertEqual(parse.path, "")
 
-        parse = self.parse_url("xet://user/repo/branch", True, default_domain='xetbeta.com')
+        parse = self.parse_url("xet://user/repo/branch", True, default_endpoint='xetbeta.com')
         self.assertEqual(parse.remote(), "https://xetbeta.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "")
@@ -106,7 +106,7 @@ class TestUrlParsing(unittest.TestCase):
         self.assertEqual(parse.branch, "")
         self.assertEqual(parse.path, "")
 
-        parse = self.parse_url("/user/repo/branch", True, default_domain='xetbeta.com')
+        parse = self.parse_url("/user/repo/branch", True, default_endpoint='xetbeta.com')
         self.assertEqual(parse.remote(), "https://xetbeta.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "")
@@ -146,7 +146,7 @@ class TestUrlParsing(unittest.TestCase):
         self.assertEqual(parse.path, "")
 
 
-        parse = self.parse_url("xet://xh.com:user/repo/branch", False, default_domain='xetbeta.com')
+        parse = self.parse_url("xet://xh.com:user/repo/branch", False, default_endpoint='xetbeta.com')
         self.assertEqual(parse.remote(), "https://xh.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "")


### PR DESCRIPTION
This PR cleans up the doc strings and error messages so that everything is consistent with the new URL format.  In particular, 

- Where the domain should be required, we use `xet://<domain>:<user>/<repo>`
- Where the domain is optional (methods of a XetFS class instantiated with a domain), it is given as `xet://[domain:]<user>/...`
- Required fields are consistently given as `<...>`, and optional fields are given as `[...]`. 

In addition, added in a couple of parsing checks that were not in prior to this. 