### PR TITLE
Replace Discord references with Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 [![License](https://img.shields.io/github/license/xetdata/pyxet?style=flat)](https://github.com/xetdata/pyxet/blob/main/LICENSE)
 [![Downloads](https://img.shields.io/pypi/dm/pyxet?style=flat)](https://pypi.python.org/pypi/pyxet/)
 [![Documentation Status](https://readthedocs.org/projects/pyxet/badge/?version=latest)](https://pyxet.readthedocs.io/en/latest/?badge=latest)
-[![Discord](https://img.shields.io/discord/1100889165777862807)](https://discord.gg/KCzmjDaDdC)
 
 pyxet is a Python library that provides a pythonic interface for
 [XetHub](https://xethub.com/).  Xethub is simple git-based system capable of
@@ -288,7 +287,7 @@ See [here](python/pyxet/README.md)
 
 # Encountering Issues?
 
-Please file a bug [here](https://github.com/xetdata/pyxet/issues/new), or
-report on our [Discord channel](https://discord.gg/KCzmjDaDdC)! 
+Please file bugs [here](https://github.com/xetdata/pyxet/issues/new), or
+report on our [Slack #support channel](https://xetdata.slack.com/join/shared_invite/zt-2doug4qz8-JZviSqPHuLBa~pw3gnk7Iw#/shared-invite/email)! 
 We are constant making improvements, especially with
 usability and performance.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ storing TBs of ML data and models in a single repository, with block-level
 data deduplication that enables hundreds of versions of similar data to be
 stored without requiring much storage. 
 
-Join our `Discord <https://discord.gg/KCzmjDaDdC>`_ to get involved. 
+Join our `Slack <https://xetdata.slack.com/join/shared_invite/zt-2doug4qz8-JZviSqPHuLBa~pw3gnk7Iw#/shared-invite/email>`_ to get involved. 
 To stay informed about updates, star this repo and sign up for 
 `XetHub <https://xethub.com/user/sign_up>`_ to get the newsletter.
 
@@ -105,7 +105,7 @@ Encountering Issues?
 ====================
 
 Please file a bug `here <https://github.com/xetdata/pyxet/issues/new>`_, or
-report on our `Discord channel <https://discord.gg/KCzmjDaDdC>`_! 
+report on our `Slack <https://xetdata.slack.com/join/shared_invite/zt-2doug4qz8-JZviSqPHuLBa~pw3gnk7Iw#/shared-invite/email>`_! 
 We are constant making improvements, especially with
 usability and performance.
 


### PR DESCRIPTION
We moved off of Discord but never updated the Pyxet docs/README.