### PR TITLE
Enable running tests in parallel

### DIFF
--- a/python/pyxet/pyxet/cli.py
+++ b/python/pyxet/pyxet/cli.py
@@ -115,6 +115,7 @@ class PyxetCLI:
         """
         print(__version__)
 
+    @staticmethod
     @cli.command()
     def cp(source: Annotated[typing.List[str], typer.Argument(help="Source file or folder to copy")],
            target: Annotated[str, typer.Argument(help="Target location of the file or folder")],

--- a/python/pyxet/scripts/build_standalone_cli.sh
+++ b/python/pyxet/scripts/build_standalone_cli.sh
@@ -4,24 +4,31 @@
 # Will build wheel in release mode, then build standalone executable using the xet packaged with the CLI
 
 if [[ ! -e pyproject.toml ]] ; then 
-    echo "Run this script in the pyxet directory using ./scripts/$0"
+    >&2 echo "Run this script in the pyxet directory using ./scripts/$0"
     exit 1
 fi
 
-source ./scripts/build_wheel.sh
+>&2 wheel_location=$(./scripts/build_wheel.sh)
 
-pip install target/wheels/pyxet-*.whl
+>&2 pip install $wheel_location 
+>&2 pip install -r ./scripts/cli_requirements.sh 
 
 OS=$(uname -s)
 
 xet_cli_path="./scripts/xet_standalone_entry.py"
-echo "Path to xet entry script = '${xet_cli_path}'"
+>&2 echo "Path to xet entry script = '${xet_cli_path}'"
 
 # Build binary
 if [[ "$OS" == "Darwin" ]]; then
-    pyinstaller --onefile "$xet_cli_path" --name xet --target-arch universal2 
+    >&2 pyinstaller --onefile "$xet_cli_path" --name xet --target-arch universal2 
+    cli_path="$PWD/dist/xet"
 elif [[ "$OS" == "Linux" ]] ; then
-    pyinstaller --onefile "$xet_cli_path" --name xet
+    >&2 pyinstaller --onefile "$xet_cli_path" --name xet
+    cli_path="$PWD/dist/xet"
 else
-    pyinstaller --onefile "$xet_cli_path" --name xet
+    >&2 pyinstaller --onefile "$xet_cli_path" --name xet
+    cli_path="$PWD/dist/xet.exe"
 fi
+
+>&2 echo "Standalone installer is located at ${cli_path}."
+echo ${cli_path} 

--- a/python/pyxet/scripts/build_standalone_cli.sh
+++ b/python/pyxet/scripts/build_standalone_cli.sh
@@ -14,21 +14,14 @@ pip install target/wheels/pyxet-*.whl
 
 OS=$(uname -s)
 
+xet_cli_path="./scripts/xet_standalone_entry.py"
+echo "Path to xet entry script = '${xet_cli_path}'"
+
 # Build binary
 if [[ "$OS" == "Darwin" ]]; then
-    xet_cli_path="$(which xet)"
-    echo "Path to xet = '${xet_cli_path}'"
-    pyinstaller --onefile "$xet_cli_path" --target-arch universal2
+    pyinstaller --onefile "$xet_cli_path" --name xet --target-arch universal2 
 elif [[ "$OS" == "Linux" ]] ; then
-    xet_cli_path="$(which xet)"
-    echo "Path to xet = '${xet_cli_path}'"
-    pyinstaller --onefile "$xet_cli_path" 
+    pyinstaller --onefile "$xet_cli_path" --name xet
 else
-    # Windows is weird.  Have to go directly to the cli path
-
-    # Find the cli file, which isn't always where you want it to be. 
-    xet_cli_path="./.venv_build/Lib/site-packages/pyxet/cli.py"
-    echo "Path to xet = '${xet_cli_path}'"
-    pyinstaller --onefile "$xet_cli_path" 
-    mv dist/cli.exe dist/xet.exe
+    pyinstaller --onefile "$xet_cli_path" --name xet
 fi

--- a/python/pyxet/scripts/build_standalone_cli.sh
+++ b/python/pyxet/scripts/build_standalone_cli.sh
@@ -11,7 +11,7 @@ fi
 >&2 wheel_location=$(./scripts/build_wheel.sh)
 
 >&2 pip install $wheel_location 
->&2 pip install -r ./scripts/cli_requirements.sh 
+>&2 pip install -r ./scripts/cli_requirements.txt 
 
 OS=$(uname -s)
 
@@ -20,7 +20,13 @@ xet_cli_path="./scripts/xet_standalone_entry.py"
 
 # Build binary
 if [[ "$OS" == "Darwin" ]]; then
-    >&2 pyinstaller --onefile "$xet_cli_path" --name xet --target-arch universal2 
+    if [[ ${_PYXET_BUILD_MODE} == "debug" ]] ; then 
+        target_flag=
+    else
+        target_flag="--target-arch=universal2" 
+    fi
+
+    >&2 pyinstaller --onefile "$xet_cli_path" --name xet $target_flag
     cli_path="$PWD/dist/xet"
 elif [[ "$OS" == "Linux" ]] ; then
     >&2 pyinstaller --onefile "$xet_cli_path" --name xet

--- a/python/pyxet/scripts/build_wheel.sh
+++ b/python/pyxet/scripts/build_wheel.sh
@@ -13,13 +13,15 @@ OS=$(uname -s)
 export MACOSX_DEPLOYMENT_TARGET=10.9
 unset CONDA_PREFIX
 
+# Adds in the install instructions.
+>&2 source ./scripts/setup_env.sh
+
 # Use a new build environment that links against the system python on OSX 
 # and always creates a new environment.
 
 # If we're already in a virtual env, then don't worry about this. 
-if [[ -z $_PYXET_BUILD_VIRTUAL_ENV]] ; then
+if [[ -z $_PYXET_BUILD_VIRTUAL_ENV ]] ; then
     >&2 rm -rf .venv_build
-    >&2 source ./scripts/setup_env.sh
     >&2 create_venv .venv_build release  
     >&2 source $(venv_activate_script .venv_build)
 else 
@@ -32,18 +34,18 @@ fi
 
 # Mode
 if [[ $_PYXET_BUILD_MODE == "debug" ]] ; then 
-    flags="--debug"
+    flags=
 else
     flags="--profile=cli-release"
+
+    if [[ "$OS" == "Darwin" ]]; then
+        flags="$flags --target=universal2-apple-darwin"
+    fi
 fi
 
+>&2 maturin build $flags 
 
-if [[ "$OS" == "Darwin" ]]; then
-    >&2 maturin build $flags --target=universal2-apple-darwin 
-else  
-    >&2 maturin build $flags 
-fi
-
->&2 echo "Wheel is located at target/wheels/pyxet-*.whl"
-echo "${PWD}/target/wheels/pyxet-*.whl"
+wheel=$PWD/$(ls target/wheels/pyxet-*.whl | head -n 1)
+>&2 echo "Wheel is located at $wheel"
+echo $wheel
 

--- a/python/pyxet/scripts/cli_requirements.txt
+++ b/python/pyxet/scripts/cli_requirements.txt
@@ -1,0 +1,3 @@
+# All of the requirements for installation that the fsspec implementation 
+# could be interested in. 
+s3fs

--- a/python/pyxet/scripts/run_tests.sh
+++ b/python/pyxet/scripts/run_tests.sh
@@ -39,4 +39,4 @@ work_dir="$(mktemp -d -p "${PWD}/testing_tmp")"
 cp "${cli}" "${work_dir}"
 export XET_STANDALONE_CLI=${work_dir}/$(basename "$cli")
 cd "${work_dir}"
-pytest --verbose "$tests_dir"
+pytest -n 12 --verbose "$tests_dir"

--- a/python/pyxet/scripts/run_tests.sh
+++ b/python/pyxet/scripts/run_tests.sh
@@ -31,4 +31,4 @@ fi
 
 # Set this so we can execute the 
 export XET_STANDALONE_CLI=${cli}
-pytest -n 8 --verbose tests/
+pytest -n 4 --verbose tests/

--- a/python/pyxet/scripts/run_tests.sh
+++ b/python/pyxet/scripts/run_tests.sh
@@ -29,6 +29,14 @@ if [[ -z "$VIRTUAL_ENV" ]] ; then
   exit 1
 fi
 
-# Set this so we can execute the 
-export XET_STANDALONE_CLI=${cli}
-pytest -n 4 --verbose tests/
+# Set this so we can execute the scripts properly
+tests_dir=${PWD}/tests/
+
+# Make sure windows executable can run anywhere 
+mkdir -p ./testing_tmp/
+work_dir="$(mktemp -d -p "${PWD}/testing_tmp")"
+
+cp "${cli}" "${work_dir}"
+export XET_STANDALONE_CLI=${work_dir}/$(basename "$cli")
+cd "${work_dir}"
+pytest -n 4 --verbose "$tests_dir"

--- a/python/pyxet/scripts/run_tests.sh
+++ b/python/pyxet/scripts/run_tests.sh
@@ -9,26 +9,26 @@ if [[ ! -e pyproject.toml ]] ; then
 fi
 
 source ./scripts/setup_env.sh
-create_venv venv dev
+create_venv venv dev  # The dev part here installs the additional dev requirements
 source $(venv_activate_script venv)
+
+export _PYXET_BUILD_MODE=debug
+export _PYXET_BUILD_VIRTUAL_ENV=venv
+
+# Build the wheel.
+wheel=$(./scripts/build_wheel.sh)
+
+# Build the standalone cli and wheel 
+cli=$(./scripts/build_standalone_cli.sh)
+
+# Install the wheel
+pip install "$wheel"
 
 if [[ -z "$VIRTUAL_ENV" ]] ; then 
   echo "Failed to activate virtual env."
   exit 1
 fi
 
-
-# Clear out any old wheels
-mkdir -p target/old_wheels/
-mv target/wheels/* target/old_wheels/ || echo ""
-
-echo "$(which pip)"
-
-# Install 
-maturin build
-pip install target/wheels/pyxet-*.whl
-
-# TODO: This runs the tests in parallel using pytest-xdist
-# Error: tests in cli can't be run simultaneously actually, as there are conflicts.
-#pytest -n 12 --verbose tests/
-pytest --verbose tests/
+# Set this so we can execute the 
+export XET_STANDALONE_CLI=${cli}
+pytest -n 8 --verbose tests/

--- a/python/pyxet/scripts/run_tests.sh
+++ b/python/pyxet/scripts/run_tests.sh
@@ -39,4 +39,4 @@ work_dir="$(mktemp -d -p "${PWD}/testing_tmp")"
 cp "${cli}" "${work_dir}"
 export XET_STANDALONE_CLI=${work_dir}/$(basename "$cli")
 cd "${work_dir}"
-pytest -n 4 --verbose "$tests_dir"
+pytest --verbose "$tests_dir"

--- a/python/pyxet/scripts/run_tests.sh
+++ b/python/pyxet/scripts/run_tests.sh
@@ -32,4 +32,3 @@ pip install target/wheels/pyxet-*.whl
 # Error: tests in cli can't be run simultaneously actually, as there are conflicts.
 #pytest -n 12 --verbose tests/
 pytest --verbose tests/
-

--- a/python/pyxet/scripts/setup_env.sh
+++ b/python/pyxet/scripts/setup_env.sh
@@ -36,14 +36,17 @@ create_venv() {
         [[ -e "./$venv_name" ]] || exit 1 
 
         source $(venv_activate_script $venv_name)
-
-        >&2 pip install --upgrade pip
-        if [[ $build_mode == "release" ]] ; then 
-            # For building the wheel / standalone xet, use minimal installation
-            # environment; otherwise may pull in non-universal2 compatible package.
-            >&2 pip install -r scripts/build_requirements.txt
-        else
-            >&2 pip install -r scripts/dev_requirements.txt
-        fi
+    fi
+    
+    # Make sure it's up to par. 
+    >&2 pip install --upgrade pip
+    if [[ $build_mode == "release" ]] ; then 
+        # For building the wheel / standalone xet, use minimal installation
+        # environment; otherwise may pull in non-universal2 compatible package.
+        >&2 pip install --upgrade -r scripts/build_requirements.txt
+    else
+        # Install both.
+        >&2 pip install --upgrade -r scripts/build_requirements.txt
+        >&2 pip install --upgrade -r scripts/dev_requirements.txt
     fi
 }

--- a/python/pyxet/scripts/xet_standalone_entry.py
+++ b/python/pyxet/scripts/xet_standalone_entry.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+
+# Pull in everything from pyxet, without the relative imports. 
+from pyxet.cli import cli
+
+# Package in s3 dependencies, otherwise these 
+# will just give other repo errors.  
+import s3fs
+
+if __name__ == "__main__":
+    cli()

--- a/python/pyxet/tests/arrow_test.py
+++ b/python/pyxet/tests/arrow_test.py
@@ -5,23 +5,18 @@ import pytest
 import pyxet
 from utils import skip_if_no, CONSTANTS
 
-
-@pytest.mark.skip("Not sure if pyxet will implement read_arrow - TODO")
-def test_read_arrow():
-    dataset = pyxet.read_arrow(CONSTANTS.TITANIC_PARQUET)
-    assert dataset.to_table().num_rows == 891
-
+# This just ends up being one test, as this repo is currently mdbv1, and the mdb 
+# v1 clone process is not safe between multiple processes. 
 
 @skip_if_no("pyarrow")
-def test_pyarrow_dataset():
+def test_pyarrow():
     import pyarrow.dataset as ds
     fs = pyxet.XetFS(repo_url=CONSTANTS.TITANIC_MAIN)
     dataset = ds.dataset(CONSTANTS.TITANIC_PARQUET, filesystem=fs)
     assert dataset.to_table().num_rows == 891
 
 
-@skip_if_no("pyarrow")
-def test_pyarrow_parquet():
+# def test_pyarrow_parquet():
     from pyarrow.parquet import ParquetFile
     import pyarrow as pa
 
@@ -31,9 +26,7 @@ def test_pyarrow_parquet():
     df = pa.Table.from_batches([first_ten_rows]).to_pandas()
     assert df.shape == (10, 12)
 
-
-@skip_if_no("pyarrow")
-def test_pyarrow_stream():
+# def test_pyarrow_stream():
     import pandas as pd
     from pyarrow.fs import PyFileSystem, FSSpecHandler
 
@@ -44,8 +37,7 @@ def test_pyarrow_stream():
     assert df.shape == (891, 12)
 
 
-@pytest.mark.skip("cp not implemented")
-def test_pyarrow_stream_cp():
+# def test_pyarrow_stream_cp():
     with pytest.raises(NotImplementedError):  # TODO
         pa_fs.copy_file(CONSTANTS.TITANIC_CSV,
                         'https://xethub.com/xdssio/titanic.git/main/titanic2.csv')

--- a/python/pyxet/tests/test_standalone_cli.py
+++ b/python/pyxet/tests/test_standalone_cli.py
@@ -7,11 +7,14 @@ import tempfile
 
 from pyxet.file_operations import perform_copy, build_cp_action_list
 
+
 def delete_branch(repo, branch, *args): 
     try:
         pyxet.BranchCLI.delete(repo, branch, *args)
     except Exception as e:
         print(f"WARNING: Exception trying to delete branch {branch} on {repo}: {e}")
+        
+
 
 def test_single_file_upload():
     user, host = utils.test_account_login()

--- a/python/pyxet/tests/test_standalone_cli.py
+++ b/python/pyxet/tests/test_standalone_cli.py
@@ -14,8 +14,6 @@ def delete_branch(repo, branch, *args):
     except Exception as e:
         print(f"WARNING: Exception trying to delete branch {branch} on {repo}: {e}")
         
-
-
 def test_single_file_upload():
     user, host = utils.test_account_login()
     repo = utils.test_repo()


### PR DESCRIPTION
The main issue is that git xet clone with a single mdbv1 is not process safe -- two tests trying to read from a remote mdbv1 repo will cause a crash.  This fixes that specific issue by merging the mdbv1 tests into a single test that would not be run in parallel. 

The result is a significant speedup when running pyxet tests. 