### PR TITLE
Adds missing flags for releasable  process for osx builds.

### DIFF
--- a/python/pyxet/scripts/build_wheel.sh
+++ b/python/pyxet/scripts/build_wheel.sh
@@ -40,6 +40,7 @@ else
 
     if [[ "$OS" == "Darwin" ]]; then
         flags="$flags --target=universal2-apple-darwin"
+        export CXXFLAGS="-stdlib=libc++"
     fi
 fi
 


### PR DESCRIPTION
./scripts/build_wheel.sh should build the wheel in the same way as needed for distribution.  This adds a flag that is part of the CI build but not in this script. 