### PR TITLE
Fixes for url parsing around including port in endpoint. 

### DIFF
--- a/python/pyxet/pyxet/url_parsing.py
+++ b/python/pyxet/pyxet/url_parsing.py
@@ -55,7 +55,11 @@ class XetPathInfo:
         return "/".join(s for s in [self.repo, self.branch, self.path] if s)
 
     def url(self):
-        return f"{self.scheme}://{self.endpoint}:{self.user}/{self._repo_branch_path()}"
+        if self.scheme in ["http", "https"]:
+            return f"{self.scheme}://{self.endpoint}/{self.user}/{self._repo_branch_path()}"
+        else:
+            return f"{self.scheme}://{self.endpoint}:{self.user}/{self._repo_branch_path()}"
+
 
     def base_path(self): 
         """

--- a/python/pyxet/pyxet/url_parsing.py
+++ b/python/pyxet/pyxet/url_parsing.py
@@ -146,7 +146,7 @@ def parse_url(url, default_endpoint=None, expect_branch = None, expect_repo = Tr
     # Set this as a default below     
     ret = XetPathInfo()
     # Set what defaults we can
-    ret.scheme = "xet"
+    ret.scheme = scheme
     ret.http_scheme = "https"
 
     netloc_info = url_path.split("/", 1)
@@ -157,10 +157,13 @@ def parse_url(url, default_endpoint=None, expect_branch = None, expect_repo = Tr
     else:
         netloc, path = netloc_info
 
-    # Handle the case where we are xet://user/repo. In which case the endpoint
-    # parsed is not xethub.com and endpoint="user".
-    # we rewrite the parse the handle this case early.
-    if ":" not in netloc:
+    if scheme in ["http", "https"]:
+        # Here we assume the endpoint is always explicit
+        ret.endpoint = netloc
+        path_to_parse = path  
+        ret.endpoint_explicit = True
+        explicit_user = None
+    elif ":" not in netloc:
         
         global has_warned_user_on_url_format
 
@@ -190,7 +193,7 @@ def parse_url(url, default_endpoint=None, expect_branch = None, expect_repo = Tr
                 ret.endpoint = default_endpoint
         else: 
             raise ValueError(f"Cannot parse user and endpoint from {netloc}")
-        
+
         ret.endpoint_explicit = True
 
     # Now, special case localhost

--- a/python/pyxet/tests/url_parsing.py
+++ b/python/pyxet/tests/url_parsing.py
@@ -12,67 +12,78 @@ class TestUrlParsing(unittest.TestCase):
         self.assertEqual(parse, url_parsing.parse_url(parse.url()))
         return parse
 
-    def test_parse_xet_url(self):
+    def test_parse_xet_url_1(self):
         parse = self.parse_url("xet://xethub.com/user/repo/branch/hello/world", True)
         self.assertEqual(parse.remote(), "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "hello/world")
 
+    def test_parse_xet_url_2(self):
         parse = self.parse_url("xet://xethub.com/user/repo/branch/hello/world/", True)
         self.assertEqual(parse.remote(), "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "hello/world/")
 
+    def test_parse_xet_url_3(self):
         parse = self.parse_url("xet://xethub.com/user/repo/branch/", True)
         self.assertEqual(parse.remote(), "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "")
 
+    def test_parse_xet_url_4(self):
         parse = self.parse_url("xet://xethub.com/user/repo/branch", True)
         self.assertEqual(parse.remote(), "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "")
 
+    def test_parse_xet_url_5(self):
         parse = self.parse_url("xet://xethub.com/user/repo", True)
         self.assertEqual(parse.remote(), "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "")
         self.assertEqual(parse.path, "")
 
-        parse = self.parse_url("xet://xethub.com/user/repo/branch", True, default_endpoint='xetbeta.com')
+    def test_parse_xet_url_6(self):
+        parse = self.parse_url("xet://xethub.com/user/repo/branch", False, default_endpoint='xetbeta.com')
         self.assertEqual(parse.remote(), "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "")
 
+    def test_parse_xet_url_7(self):
         with self.assertRaises(ValueError):
             self.parse = self.parse_url("xet://xethub.com/user", True)
 
-    def test_parse_xet_url_truncated(self):
+    def test_parse_xet_url_truncated_1(self):
         parse = self.parse_url("xet://user/repo/branch/hello/world", True)
         self.assertEqual(parse.remote(), "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "hello/world")
 
+    def test_parse_xet_url_truncated_2(self):
         parse = self.parse_url("xet://user/repo/branch/hello/world/", True)
         self.assertEqual(parse.remote(), "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "hello/world/")
 
+    def test_parse_xet_url_truncated_3(self):
         parse = self.parse_url("xet://user/repo/branch/", True)
         self.assertEqual(parse.remote(), "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "")
 
+    def test_parse_xet_url_truncated_4(self):
         parse = self.parse_url("xet://user/repo/branch", True)
         self.assertEqual(parse.remote(), "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "")
 
+    def test_parse_xet_url_truncated_5(self):
         parse = self.parse_url("xet://user/repo", True)
         self.assertEqual(parse.remote(), "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "")
         self.assertEqual(parse.path, "")
 
-        parse = self.parse_url("xet://user/repo/branch", True, default_endpoint='xetbeta.com')
+    def test_parse_xet_url_truncated_6(self):
+        parse = self.parse_url("xet://user/repo/branch", False, default_endpoint='xetbeta.com')
         self.assertEqual(parse.remote(), "https://xetbeta.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "")
@@ -80,103 +91,119 @@ class TestUrlParsing(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.parse = self.parse_url("xet://user", True)
 
-    def test_parse_plain_path(self):
+    def test_parse_plain_path_1(self):
         parse = self.parse_url("/user/repo/branch/hello/world", True)
         self.assertEqual(parse.remote(), "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "hello/world")
 
+    def test_parse_plain_path_2(self):
         parse = self.parse_url("/user/repo/branch/hello/world/", True)
         self.assertEqual(parse.remote(), "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "hello/world/")
 
+    def test_parse_plain_path_3(self):
         parse = self.parse_url("/user/repo/branch/", True)
         self.assertEqual(parse.remote(), "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "")
 
+    def test_parse_plain_path_4(self):
         parse = self.parse_url("/user/repo/branch", True)
         self.assertEqual(parse.remote(), "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "")
 
+    def test_parse_plain_path_5(self):
         parse = self.parse_url("/user/repo", True)
         self.assertEqual(parse.remote(), "https://xethub.com/user/repo")
         self.assertEqual(parse.branch, "")
         self.assertEqual(parse.path, "")
 
-        parse = self.parse_url("/user/repo/branch", True, default_endpoint='xetbeta.com')
+    def test_parse_plain_path_6(self):
+        parse = self.parse_url("/user/repo/branch", False, default_endpoint='xetbeta.com')
         self.assertEqual(parse.remote(), "https://xetbeta.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "")
 
+    def test_parse_plain_path_7(self):
         with self.assertRaises(ValueError):
             self.parse = self.parse_url("xet://xethub.com/user", True)
 
-    def test_parse_xet_url_correct(self):
+    def test_parse_xet_url_correct_1(self):
         parse = self.parse_url("xet://xh.com:user/repo/branch/hello/world", False)
         self.assertEqual(parse.remote(), "https://xh.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "hello/world")
 
+    def test_parse_xet_url_correct_2(self):
         parse = self.parse_url("xet://xh.com:user/repo/branch/hello/world/", False)
         self.assertEqual(parse.remote(), "https://xh.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "hello/world/")
 
+    def test_parse_xet_url_correct_3(self):
         parse = self.parse_url("xet://xh.com:user/repo/branch/", False)
         self.assertEqual(parse.remote(), "https://xh.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "")
 
+    def test_parse_xet_url_correct_4(self):
         parse = self.parse_url("xet://xh.com:user/repo/branch", False)
         self.assertEqual(parse.remote(), "https://xh.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "")
 
+    def test_parse_xet_url_correct_5(self):
         parse = self.parse_url("xet://xh.com:user/repo", False)
         self.assertEqual(parse.remote(), "https://xh.com/user/repo")
         self.assertEqual(parse.branch, "")
         self.assertEqual(parse.path, "")
 
+    def test_parse_xet_url_correct_6(self):
         parse = self.parse_url("xet://hub.xetsvc.com:XetHub/Flickr30k/main", False)
         self.assertEqual(parse.remote(), "https://hub.xetsvc.com/XetHub/Flickr30k")
         self.assertEqual(parse.branch, "main")
         self.assertEqual(parse.path, "")
 
-
+    def test_parse_xet_url_correct_7(self):
         parse = self.parse_url("xet://xh.com:user/repo/branch", False, default_endpoint='xetbeta.com')
         self.assertEqual(parse.remote(), "https://xh.com/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "")
 
-    def test_ports(self):
+    def test_ports_1(self):
         parse = self.parse_url("xet://localhost:1234:user/repo/branch/hello/world", False)
         self.assertEqual(parse.remote(), "http://localhost:1234/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "hello/world")
         
+    def test_ports_2(self):
         parse = self.parse_url("xet://127.0.0.1:1234:user/repo/branch/hello/world", False)
         self.assertEqual(parse.remote(), "http://127.0.0.1:1234/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "hello/world")
 
+    def test_ports_3(self):
         parse = self.parse_url("xet://xh.com:1234:user/repo/branch/hello/world/", False)
         self.assertEqual(parse.remote(), "https://xh.com:1234/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "hello/world/")
         
+    def test_ports_4(self):
         parse = self.parse_url("http://localhost:1234/user/repo/branch/hello/world", False)
         self.assertEqual(parse.remote(), "http://localhost:1234/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "hello/world")
         
+    def test_ports_5(self):
         parse = self.parse_url("http://127.0.0.1:1234/user/repo/branch/hello/world", False)
         self.assertEqual(parse.remote(), "http://127.0.0.1:1234/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "hello/world")
 
+    def test_ports_6(self):
         parse = self.parse_url("https://xh.com:1234/user/repo/branch/hello/world/", False)
         self.assertEqual(parse.remote(), "https://xh.com:1234/user/repo")
         self.assertEqual(parse.branch, "branch")

--- a/python/pyxet/tests/url_parsing.py
+++ b/python/pyxet/tests/url_parsing.py
@@ -166,3 +166,18 @@ class TestUrlParsing(unittest.TestCase):
         self.assertEqual(parse.remote(), "https://xh.com:1234/user/repo")
         self.assertEqual(parse.branch, "branch")
         self.assertEqual(parse.path, "hello/world/")
+        
+        parse = self.parse_url("http://localhost:1234/user/repo/branch/hello/world", False)
+        self.assertEqual(parse.remote(), "http://localhost:1234/user/repo")
+        self.assertEqual(parse.branch, "branch")
+        self.assertEqual(parse.path, "hello/world")
+        
+        parse = self.parse_url("http://127.0.0.1:1234/user/repo/branch/hello/world", False)
+        self.assertEqual(parse.remote(), "http://127.0.0.1:1234/user/repo")
+        self.assertEqual(parse.branch, "branch")
+        self.assertEqual(parse.path, "hello/world")
+
+        parse = self.parse_url("https://xh.com:1234/user/repo/branch/hello/world/", False)
+        self.assertEqual(parse.remote(), "https://xh.com:1234/user/repo")
+        self.assertEqual(parse.branch, "branch")
+        self.assertEqual(parse.path, "hello/world/")


### PR DESCRIPTION
This corrects issues when using ports like http://localhost:3000/user.