### PR TITLE
Show server message on exception

### DIFF
--- a/python/pyxet/Cargo.lock
+++ b/python/pyxet/Cargo.lock
@@ -371,8 +371,8 @@ dependencies = [
 
 [[package]]
 name = "cache"
-version = "0.14.2"
-source = "git+https://github.com/xetdata/xet-core#097049b9e5e93bf6b9e770e56d67f44f58e1b3d9"
+version = "0.14.3"
+source = "git+https://github.com/xetdata/xet-core#82a8e93b5d86895c5b574be1a2d89dc2f4bcec9d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -396,8 +396,8 @@ dependencies = [
 
 [[package]]
 name = "cas_client"
-version = "0.14.2"
-source = "git+https://github.com/xetdata/xet-core#097049b9e5e93bf6b9e770e56d67f44f58e1b3d9"
+version = "0.14.3"
+source = "git+https://github.com/xetdata/xet-core#82a8e93b5d86895c5b574be1a2d89dc2f4bcec9d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -488,8 +488,8 @@ dependencies = [
 
 [[package]]
 name = "chunkpipe"
-version = "0.14.2"
-source = "git+https://github.com/xetdata/xet-core#097049b9e5e93bf6b9e770e56d67f44f58e1b3d9"
+version = "0.14.3"
+source = "git+https://github.com/xetdata/xet-core#82a8e93b5d86895c5b574be1a2d89dc2f4bcec9d"
 
 [[package]]
 name = "clap"
@@ -594,8 +594,11 @@ dependencies = [
 
 [[package]]
 name = "common_constants"
-version = "0.14.2"
-source = "git+https://github.com/xetdata/xet-core#097049b9e5e93bf6b9e770e56d67f44f58e1b3d9"
+version = "0.14.3"
+source = "git+https://github.com/xetdata/xet-core#82a8e93b5d86895c5b574be1a2d89dc2f4bcec9d"
+dependencies = [
+ "lazy_static",
+]
 
 [[package]]
 name = "compare"
@@ -851,8 +854,8 @@ dependencies = [
 
 [[package]]
 name = "data_analysis"
-version = "0.14.2"
-source = "git+https://github.com/xetdata/xet-core#097049b9e5e93bf6b9e770e56d67f44f58e1b3d9"
+version = "0.14.3"
+source = "git+https://github.com/xetdata/xet-core#82a8e93b5d86895c5b574be1a2d89dc2f4bcec9d"
 dependencies = [
  "approx",
  "cxx",
@@ -1026,8 +1029,8 @@ dependencies = [
 
 [[package]]
 name = "error_printer"
-version = "0.14.2"
-source = "git+https://github.com/xetdata/xet-core#097049b9e5e93bf6b9e770e56d67f44f58e1b3d9"
+version = "0.14.3"
+source = "git+https://github.com/xetdata/xet-core#82a8e93b5d86895c5b574be1a2d89dc2f4bcec9d"
 dependencies = [
  "tracing",
 ]
@@ -1298,8 +1301,8 @@ dependencies = [
 
 [[package]]
 name = "gitxetcore"
-version = "0.14.2"
-source = "git+https://github.com/xetdata/xet-core#097049b9e5e93bf6b9e770e56d67f44f58e1b3d9"
+version = "0.14.3"
+source = "git+https://github.com/xetdata/xet-core#82a8e93b5d86895c5b574be1a2d89dc2f4bcec9d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2032,8 +2035,8 @@ dependencies = [
 
 [[package]]
 name = "lazy"
-version = "0.14.2"
-source = "git+https://github.com/xetdata/xet-core#097049b9e5e93bf6b9e770e56d67f44f58e1b3d9"
+version = "0.14.3"
+source = "git+https://github.com/xetdata/xet-core#82a8e93b5d86895c5b574be1a2d89dc2f4bcec9d"
 dependencies = [
  "lazy_static",
  "tokio",
@@ -2076,8 +2079,8 @@ dependencies = [
 
 [[package]]
 name = "libmagic"
-version = "0.14.2"
-source = "git+https://github.com/xetdata/xet-core#097049b9e5e93bf6b9e770e56d67f44f58e1b3d9"
+version = "0.14.3"
+source = "git+https://github.com/xetdata/xet-core#82a8e93b5d86895c5b574be1a2d89dc2f4bcec9d"
 dependencies = [
  "anyhow",
  "phf",
@@ -2100,8 +2103,8 @@ dependencies = [
 
 [[package]]
 name = "libxet"
-version = "0.14.2"
-source = "git+https://github.com/xetdata/xet-core#097049b9e5e93bf6b9e770e56d67f44f58e1b3d9"
+version = "0.14.3"
+source = "git+https://github.com/xetdata/xet-core#82a8e93b5d86895c5b574be1a2d89dc2f4bcec9d"
 dependencies = [
  "gitxetcore",
  "progress_reporting",
@@ -2219,8 +2222,8 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "mdb_shard"
-version = "0.14.2"
-source = "git+https://github.com/xetdata/xet-core#097049b9e5e93bf6b9e770e56d67f44f58e1b3d9"
+version = "0.14.3"
+source = "git+https://github.com/xetdata/xet-core#82a8e93b5d86895c5b574be1a2d89dc2f4bcec9d"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -2259,8 +2262,8 @@ dependencies = [
 
 [[package]]
 name = "merkledb"
-version = "0.14.2"
-source = "git+https://github.com/xetdata/xet-core#097049b9e5e93bf6b9e770e56d67f44f58e1b3d9"
+version = "0.14.3"
+source = "git+https://github.com/xetdata/xet-core#82a8e93b5d86895c5b574be1a2d89dc2f4bcec9d"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2290,8 +2293,8 @@ dependencies = [
 
 [[package]]
 name = "merklehash"
-version = "0.14.2"
-source = "git+https://github.com/xetdata/xet-core#097049b9e5e93bf6b9e770e56d67f44f58e1b3d9"
+version = "0.14.3"
+source = "git+https://github.com/xetdata/xet-core#82a8e93b5d86895c5b574be1a2d89dc2f4bcec9d"
 dependencies = [
  "blake3",
  "generic-array",
@@ -2755,8 +2758,8 @@ dependencies = [
 
 [[package]]
 name = "parutils"
-version = "0.14.2"
-source = "git+https://github.com/xetdata/xet-core#097049b9e5e93bf6b9e770e56d67f44f58e1b3d9"
+version = "0.14.3"
+source = "git+https://github.com/xetdata/xet-core#82a8e93b5d86895c5b574be1a2d89dc2f4bcec9d"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -3014,8 +3017,8 @@ dependencies = [
 
 [[package]]
 name = "progress_reporting"
-version = "0.14.2"
-source = "git+https://github.com/xetdata/xet-core#097049b9e5e93bf6b9e770e56d67f44f58e1b3d9"
+version = "0.14.3"
+source = "git+https://github.com/xetdata/xet-core#82a8e93b5d86895c5b574be1a2d89dc2f4bcec9d"
 dependencies = [
  "atty",
  "crossterm",
@@ -3042,8 +3045,8 @@ dependencies = [
 
 [[package]]
 name = "prometheus_dict_encoder"
-version = "0.14.2"
-source = "git+https://github.com/xetdata/xet-core#097049b9e5e93bf6b9e770e56d67f44f58e1b3d9"
+version = "0.14.3"
+source = "git+https://github.com/xetdata/xet-core#82a8e93b5d86895c5b574be1a2d89dc2f4bcec9d"
 dependencies = [
  "memchr",
  "prometheus",
@@ -3459,8 +3462,8 @@ checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
 
 [[package]]
 name = "retry_strategy"
-version = "0.14.2"
-source = "git+https://github.com/xetdata/xet-core#097049b9e5e93bf6b9e770e56d67f44f58e1b3d9"
+version = "0.14.3"
+source = "git+https://github.com/xetdata/xet-core#82a8e93b5d86895c5b574be1a2d89dc2f4bcec9d"
 dependencies = [
  "tokio-retry",
 ]
@@ -3826,8 +3829,8 @@ dependencies = [
 
 [[package]]
 name = "shard_client"
-version = "0.14.2"
-source = "git+https://github.com/xetdata/xet-core#097049b9e5e93bf6b9e770e56d67f44f58e1b3d9"
+version = "0.14.3"
+source = "git+https://github.com/xetdata/xet-core#82a8e93b5d86895c5b574be1a2d89dc2f4bcec9d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4152,8 +4155,8 @@ dependencies = [
 
 [[package]]
 name = "tableau_summary"
-version = "0.14.2"
-source = "git+https://github.com/xetdata/xet-core#097049b9e5e93bf6b9e770e56d67f44f58e1b3d9"
+version = "0.14.3"
+source = "git+https://github.com/xetdata/xet-core#82a8e93b5d86895c5b574be1a2d89dc2f4bcec9d"
 dependencies = [
  "anyhow",
  "error_printer",
@@ -4781,8 +4784,8 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utils"
-version = "0.14.2"
-source = "git+https://github.com/xetdata/xet-core#097049b9e5e93bf6b9e770e56d67f44f58e1b3d9"
+version = "0.14.3"
+source = "git+https://github.com/xetdata/xet-core#82a8e93b5d86895c5b574be1a2d89dc2f4bcec9d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5184,7 +5187,7 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 [[package]]
 name = "xet-error-impl"
 version = "1.0.50"
-source = "git+https://github.com/xetdata/xet-core#097049b9e5e93bf6b9e770e56d67f44f58e1b3d9"
+source = "git+https://github.com/xetdata/xet-core#82a8e93b5d86895c5b574be1a2d89dc2f4bcec9d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5193,8 +5196,8 @@ dependencies = [
 
 [[package]]
 name = "xet_config"
-version = "0.14.2"
-source = "git+https://github.com/xetdata/xet-core#097049b9e5e93bf6b9e770e56d67f44f58e1b3d9"
+version = "0.14.3"
+source = "git+https://github.com/xetdata/xet-core#82a8e93b5d86895c5b574be1a2d89dc2f4bcec9d"
 dependencies = [
  "config",
  "dirs 4.0.0",
@@ -5206,8 +5209,8 @@ dependencies = [
 
 [[package]]
 name = "xet_error"
-version = "0.14.2"
-source = "git+https://github.com/xetdata/xet-core#097049b9e5e93bf6b9e770e56d67f44f58e1b3d9"
+version = "0.14.3"
+source = "git+https://github.com/xetdata/xet-core#82a8e93b5d86895c5b574be1a2d89dc2f4bcec9d"
 dependencies = [
  "lazy_static",
  "xet-error-impl",

--- a/python/pyxet/pyxet/cli.py
+++ b/python/pyxet/pyxet/cli.py
@@ -179,7 +179,8 @@ class PyxetCLI:
                 print(tabulate(listing, headers="keys"))
             return listing
         except Exception as e:
-            raise
+            print(f"{e}")
+            return
             # this failed to list. retry as a file
             if fs.protocol == 'xet':
                 return PyxetCLI.info(original_path, raw)
@@ -409,7 +410,6 @@ class BranchCLI:
         ret = fs.find_ref(repo, branch)
         print(ret)
         return ret
-
 
 class RepoCLI:
     @staticmethod

--- a/python/pyxet/pyxet/cli.py
+++ b/python/pyxet/pyxet/cli.py
@@ -180,7 +180,7 @@ class PyxetCLI:
             return listing
         except Exception as e:
             print(f"{e}")
-            return
+            sys.exit(1)
             # this failed to list. retry as a file
             if fs.protocol == 'xet':
                 return PyxetCLI.info(original_path, raw)

--- a/python/pyxet/pyxet/file_system.py
+++ b/python/pyxet/pyxet/file_system.py
@@ -200,7 +200,7 @@ class XetFS(fsspec.spec.AbstractFileSystem):
                 "type": attr.ftype}
         except Exception as e:
                 print(f"{e}")
-                exit()
+                sys.exit(1)
 
     def branch_exists(self, url):
         try:
@@ -228,7 +228,7 @@ class XetFS(fsspec.spec.AbstractFileSystem):
                     "last_modified": None if len(attr.last_modified) == 0 else attr.last_modified}
         except Exception as e:
             print(f"{e}")
-            exit()
+            sys.exit(1)
 
     def make_repo(self, dest_path, private=False, **kwargs):
         dest = parse_url(dest_path, self.endpoint, expect_branch = False, expect_repo=True)

--- a/python/pyxet/pyxet/file_system.py
+++ b/python/pyxet/pyxet/file_system.py
@@ -192,15 +192,16 @@ class XetFS(fsspec.spec.AbstractFileSystem):
 
         try:
             attr = self._manager.stat(url_path.remote(), url_path.branch, "")
-            if attr is None:
-                raise FileNotFoundError(
-                    f"Branch or repo not found, remote = {url_path.remote()}, branch = {url_path.branch}")
-            return {"name": url_path.name(),
-                "size": attr.size,
-                "type": attr.ftype}
         except Exception as e:
-                print(f"{e}")
-                sys.exit(1)
+            print(f"{e}")
+            sys.exit(1)
+        if attr is None:
+            raise FileNotFoundError(
+                f"Branch or repo not found, remote = {url_path.remote()}, branch = {url_path.branch}")
+        return {"name": url_path.name(),
+            "size": attr.size,
+            "type": attr.ftype}
+        
 
     def branch_exists(self, url):
         try:
@@ -218,17 +219,18 @@ class XetFS(fsspec.spec.AbstractFileSystem):
         url_path = parse_url(url, self.endpoint, expect_branch = True)
         try:
             attr = self._manager.stat(url_path.remote(), url_path.branch, url_path.path)
-
-            if attr is None:
-                raise FileNotFoundError(f"File not found {url}")
-
-            return {"name": url_path.name(),
-                    "size": attr.size,
-                    "type": attr.ftype,
-                    "last_modified": None if len(attr.last_modified) == 0 else attr.last_modified}
         except Exception as e:
             print(f"{e}")
             sys.exit(1)
+
+        if attr is None:
+            raise FileNotFoundError(f"File not found {url}")
+
+        return {"name": url_path.name(),
+                "size": attr.size,
+                "type": attr.ftype,
+                "last_modified": None if len(attr.last_modified) == 0 else attr.last_modified}
+        
 
     def make_repo(self, dest_path, private=False, **kwargs):
         dest = parse_url(dest_path, self.endpoint, expect_branch = False, expect_repo=True)

--- a/python/pyxet/pyxet/file_system.py
+++ b/python/pyxet/pyxet/file_system.py
@@ -190,16 +190,17 @@ class XetFS(fsspec.spec.AbstractFileSystem):
         else:
             url_path = parse_url(url, self.endpoint, expect_branch = True)
 
-        attr = self._manager.stat(url_path.remote(), url_path.branch, "")
-
-        if attr is None:
-            raise FileNotFoundError(
-                f"Branch or repo not found, remote = {url_path.remote()}, branch = {url_path.branch}")
-
-        return {"name": url_path.name(),
+        try:
+            attr = self._manager.stat(url_path.remote(), url_path.branch, "")
+            if attr is None:
+                raise FileNotFoundError(
+                    f"Branch or repo not found, remote = {url_path.remote()}, branch = {url_path.branch}")
+            return {"name": url_path.name(),
                 "size": attr.size,
                 "type": attr.ftype}
-
+        except Exception as e:
+                print(f"{e}")
+                exit()
 
     def branch_exists(self, url):
         try:
@@ -215,15 +216,19 @@ class XetFS(fsspec.spec.AbstractFileSystem):
         or `xet://[endpoint:]<user>/<repo>/<branch>/[path]`
         """
         url_path = parse_url(url, self.endpoint, expect_branch = True)
-        attr = self._manager.stat(url_path.remote(), url_path.branch, url_path.path)
+        try:
+            attr = self._manager.stat(url_path.remote(), url_path.branch, url_path.path)
 
-        if attr is None:
-            raise FileNotFoundError(f"File not found {url}")
+            if attr is None:
+                raise FileNotFoundError(f"File not found {url}")
 
-        return {"name": url_path.name(),
-                "size": attr.size,
-                "type": attr.ftype,
-                "last_modified": None if len(attr.last_modified) == 0 else attr.last_modified}
+            return {"name": url_path.name(),
+                    "size": attr.size,
+                    "type": attr.ftype,
+                    "last_modified": None if len(attr.last_modified) == 0 else attr.last_modified}
+        except Exception as e:
+            print(f"{e}")
+            exit()
 
     def make_repo(self, dest_path, private=False, **kwargs):
         dest = parse_url(dest_path, self.endpoint, expect_branch = False, expect_repo=True)


### PR DESCRIPTION
Depends on https://github.com/xetdata/xet-core/pull/391. Fix FUN-90.

Some tests on most used path:
```
(.env) di@di-mbp ~/xetdata/pyxet/python/pyxet % xet ls xet://localhost:3000:seanses-local/comp             
Repository is not accessible to free tier accounts. Upgrade your XetHub subscription to access private repositories: http://localhost:3000///subscription/upgrade.
(.env) di@di-mbp ~/xetdata/pyxet/python/pyxet % xet ls xet://localhost:3000:seanses-local/comp/main
Repository is not accessible to free tier accounts. Upgrade your XetHub subscription to access private repositories: http://localhost:3000///subscription/upgrade.
(.env) di@di-mbp ~/xetdata/pyxet/python/pyxet % xet ls xet://localhost:3000:seanses-local/comp/aomen
Repository is not accessible to free tier accounts. Upgrade your XetHub subscription to access private repositories: http://localhost:3000///subscription/upgrade.
(.env) di@di-mbp ~/xetdata/pyxet/python/pyxet % xet cp -r xet://localhost:3000:seanses-local/comp/main .
Repository is not accessible to free tier accounts. Upgrade your XetHub subscription to access private repositories: http://localhost:3000///subscription/upgrade.
(.env) di@di-mbp ~/xetdata/pyxet/python/pyxet % xet cp -r src xet://localhost:3000:seanses-local/comp/main        
Repository is not accessible to free tier accounts. Upgrade your XetHub subscription to access private repositories: http://localhost:3000///subscription/upgrade.
```