### PR TITLE
Adds in a flag, set during github runs, to force all tests to run or error out

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -5,6 +5,7 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.DEV_AWS_ACCESS_KEY }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_AWS_SECRET_KEY }}
+      XET_FORCE_ALL_TESTS: 1
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]

--- a/python/pyxet/tests/utils.py
+++ b/python/pyxet/tests/utils.py
@@ -153,7 +153,7 @@ def require_s3_creds():
 
     msg = "AWS credentials not defined"
     if os.environ.get("XET_FORCE_ALL_TESTS") == "1":
-        return pytest.mark.skipif(False)
+        return pytest.mark.skipif(False, reason="") # noop
     
     return pytest.mark.skipif(not try_load_s3(), reason=msg)
 

--- a/python/pyxet/tests/utils.py
+++ b/python/pyxet/tests/utils.py
@@ -152,6 +152,9 @@ def require_s3_creds():
             return False
 
     msg = "AWS credentials not defined"
+    if os.environ.get("XET_FORCE_ALL_TESTS") == "1":
+        return pytest.mark.skipif(False)
+    
     return pytest.mark.skipif(not try_load_s3(), reason=msg)
 
 


### PR DESCRIPTION
Previously, tests were skipped if config stuff was not properly defined, which masked a lot of errors.  This flag, set during the build process, overrides that. 